### PR TITLE
Fix misspells and typos

### DIFF
--- a/frac/processor/aggregator.go
+++ b/frac/processor/aggregator.go
@@ -217,7 +217,7 @@ func (n *SingleSourceCountAggregator) Aggregate() (seq.AggregatableSamples, erro
 	}
 
 	// FIXME(dkharms): It will not work correctly with time series, since
-	// we also have to spread [notExists] accross different time bins.
+	// we also have to spread [notExists] across different time bins.
 	if n.notExists > 0 {
 		// Handle non-existent sources in legacy format.
 		aggMap[seq.AggBin{

--- a/metric/store.go
+++ b/metric/store.go
@@ -243,7 +243,7 @@ var (
 	}, []string{"stage"})
 	MaintenanceTruncateTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "seq_db_store",
-		Subsystem: "maintanance",
+		Subsystem: "maintenance",
 		Name:      "truncate_total",
 		Help:      "",
 	})

--- a/tests/integration_tests/single_test.go
+++ b/tests/integration_tests/single_test.go
@@ -502,7 +502,7 @@ func (s *SingleTestSuite) TestIndexingAllFields() {
 	}
 
 	docStrs := setup.DocsToStrings(docs)
-	// Just make sure that mapping is not overriden by something.
+	// Just make sure that mapping is not overridden by something.
 	require.Empty(s.T(), s.Ingestor().Config.Bulk.MappingProvider.GetMapping(), "mapping is not empty")
 
 	s.Bulk(docStrs)


### PR DESCRIPTION
From “Go Report Card”: https://goreportcard.com/report/github.com/ozontech/seq-db

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Corrected spelling and typo errors in comments for improved clarity.
  * Fixed a typo in a metric subsystem name to ensure accurate labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->