### PR TITLE
refactor: rename `disk` package to `storage`

### DIFF
--- a/cmd/distribution/main.go
+++ b/cmd/distribution/main.go
@@ -11,20 +11,20 @@ import (
 
 	"github.com/ozontech/seq-db/cache"
 	"github.com/ozontech/seq-db/consts"
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/frac"
 	"github.com/ozontech/seq-db/fracmanager"
 	"github.com/ozontech/seq-db/logger"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/storage"
 	"github.com/ozontech/seq-db/util"
 )
 
 const savePeriod = 30 * time.Second
 
-var readLimiter *disk.ReadLimiter
+var readLimiter *storage.ReadLimiter
 
 func init() {
-	readLimiter = disk.NewReadLimiter(1, nil)
+	readLimiter = storage.NewReadLimiter(1, nil)
 }
 
 func printDistribution(dist *seq.MIDsDistribution) {
@@ -41,16 +41,16 @@ func getAllFracs(dataDir string) []string {
 	return files
 }
 
-func getReader(path string) (disk.IndexReader, *os.File) {
+func getReader(path string) (storage.IndexReader, *os.File) {
 	c := cache.NewCache[[]byte](nil, nil)
 	f, err := os.Open(path)
 	if err != nil {
 		panic(err)
 	}
-	return disk.NewIndexReader(readLimiter, f, c), f
+	return storage.NewIndexReader(readLimiter, f.Name(), f, c), f
 }
 
-func readBlock(reader disk.IndexReader, blockIndex uint32) ([]byte, error) {
+func readBlock(reader storage.IndexReader, blockIndex uint32) ([]byte, error) {
 	data, _, err := reader.ReadIndexBlock(blockIndex, nil)
 	if err != nil {
 		return nil, err

--- a/cmd/index_analyzer/main.go
+++ b/cmd/index_analyzer/main.go
@@ -7,16 +7,15 @@ import (
 	"os"
 	"time"
 
+	"github.com/alecthomas/units"
 	"go.uber.org/zap"
 
-	"github.com/alecthomas/units"
-
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/frac"
 	"github.com/ozontech/seq-db/frac/sealed/lids"
 	"github.com/ozontech/seq-db/frac/sealed/token"
 	"github.com/ozontech/seq-db/fracmanager"
 	"github.com/ozontech/seq-db/logger"
+	"github.com/ozontech/seq-db/storage"
 )
 
 // Launch as:
@@ -31,7 +30,7 @@ func main() {
 	cm, stopFn := getCacheMaintainer()
 	defer stopFn()
 
-	readLimiter := disk.NewReadLimiter(1, nil)
+	readLimiter := storage.NewReadLimiter(1, nil)
 
 	mergedTokensUniq := map[string]map[string]int{}
 	mergedTokensValuesUniq := map[string]int{}
@@ -68,7 +67,7 @@ func getCacheMaintainer() (*fracmanager.CacheMaintainer, func()) {
 func analyzeIndex(
 	path string,
 	cm *fracmanager.CacheMaintainer,
-	reader *disk.ReadLimiter,
+	reader *storage.ReadLimiter,
 	mergedTokensUniq map[string]map[string]int,
 	allTokensValuesUniq map[string]int,
 ) Stats {
@@ -80,7 +79,7 @@ func analyzeIndex(
 		panic(err)
 	}
 
-	indexReader := disk.NewIndexReader(reader, f, cache.Registry)
+	indexReader := storage.NewIndexReader(reader, f.Name(), f, cache.Registry)
 
 	readBlock := func() []byte {
 		data, _, err := indexReader.ReadIndexBlock(blockIndex, nil)

--- a/cmd/unpacker/main.go
+++ b/cmd/unpacker/main.go
@@ -8,8 +8,8 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/logger"
+	"github.com/ozontech/seq-db/storage"
 )
 
 // Unpacks .docs file
@@ -46,7 +46,7 @@ func main() {
 	}
 	total := stat.Size()
 
-	reader := disk.NewDocBlocksReader(disk.NewReadLimiter(1, nil), inFile)
+	reader := storage.NewDocBlocksReader(storage.NewReadLimiter(1, nil), inFile)
 
 	offset := int64(0)
 

--- a/frac/active_index.go
+++ b/frac/active_index.go
@@ -6,7 +6,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/frac/processor"
 	"github.com/ozontech/seq-db/frac/sealed/lids"
 	"github.com/ozontech/seq-db/metric"
@@ -14,6 +13,7 @@ import (
 	"github.com/ozontech/seq-db/node"
 	"github.com/ozontech/seq-db/parser"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/storage"
 )
 
 var (
@@ -56,7 +56,7 @@ type activeDataProvider struct {
 
 	blocksOffsets []uint64
 	docsPositions *DocsPositions
-	docsReader    *disk.DocsReader
+	docsReader    *storage.DocsReader
 
 	idsIndex *activeIDsIndex
 }
@@ -245,7 +245,7 @@ func inverseLIDs(unmapped []uint32, inv *inverser, minLID, maxLID uint32) []uint
 type activeFetchIndex struct {
 	blocksOffsets []uint64
 	docsPositions *DocsPositions
-	docsReader    *disk.DocsReader
+	docsReader    *storage.DocsReader
 }
 
 func (di *activeFetchIndex) GetBlocksOffsets(num uint32) uint64 {

--- a/frac/active_indexer.go
+++ b/frac/active_indexer.go
@@ -7,10 +7,10 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ozontech/seq-db/bytespool"
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/logger"
 	"github.com/ozontech/seq-db/metric"
 	"github.com/ozontech/seq-db/metric/stopwatch"
+	"github.com/ozontech/seq-db/storage"
 )
 
 type ActiveIndexer struct {
@@ -23,7 +23,7 @@ type ActiveIndexer struct {
 
 type indexTask struct {
 	Frac  *Active
-	Metas disk.DocBlock
+	Metas storage.DocBlock
 	Pos   uint64
 	Wg    *sync.WaitGroup
 }
@@ -44,7 +44,7 @@ func NewActiveIndexer(workerCount, chLen int) *ActiveIndexer {
 func (ai *ActiveIndexer) Index(frac *Active, metas []byte, wg *sync.WaitGroup, sw *stopwatch.Stopwatch) {
 	m := sw.Start("send_index_chan")
 	ai.ch <- &indexTask{
-		Pos:   disk.DocBlock(metas).GetExt2(),
+		Pos:   storage.DocBlock(metas).GetExt2(),
 		Metas: metas,
 		Frac:  frac,
 		Wg:    wg,

--- a/frac/active_sealer.go
+++ b/frac/active_sealer.go
@@ -17,12 +17,12 @@ import (
 
 	"github.com/ozontech/seq-db/bytespool"
 	"github.com/ozontech/seq-db/consts"
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/frac/sealed/lids"
 	"github.com/ozontech/seq-db/frac/sealed/seqids"
 	"github.com/ozontech/seq-db/frac/sealed/token"
 	"github.com/ozontech/seq-db/logger"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/storage"
 	"github.com/ozontech/seq-db/util"
 )
 
@@ -218,7 +218,7 @@ func writeSealedFraction(f *Active, info *Info, indexFile io.WriteSeeker, params
 	}, nil
 }
 
-func writeDocsInOrder(pos *DocsPositions, blocks []uint64, docsReader disk.DocsReader, ids []seq.ID, bw *docBlocksWriter) error {
+func writeDocsInOrder(pos *DocsPositions, blocks []uint64, docsReader storage.DocsReader, ids []seq.ID, bw *docBlocksWriter) error {
 	// Skip system seq.ID.
 	if len(ids) == 0 {
 		panic(fmt.Errorf("BUG: ids is empty"))
@@ -234,7 +234,7 @@ func writeDocsInOrder(pos *DocsPositions, blocks []uint64, docsReader disk.DocsR
 	return nil
 }
 
-func writeDocBlocksInOrder(pos *DocsPositions, blocks []uint64, docsReader disk.DocsReader, ids []seq.ID, bw *docBlocksWriter) error {
+func writeDocBlocksInOrder(pos *DocsPositions, blocks []uint64, docsReader storage.DocsReader, ids []seq.ID, bw *docBlocksWriter) error {
 	var prevID seq.ID
 	for _, id := range ids {
 		if id == prevID {
@@ -357,7 +357,7 @@ func (w *docBlocksWriter) flushBlock() error {
 
 func (w *docBlocksWriter) compressWriteBlock() (int, error) {
 	w.blockBuf = w.blockBuf[:0]
-	w.blockBuf = disk.CompressDocBlock(w.docs, w.blockBuf, w.compressLevel)
+	w.blockBuf = storage.CompressDocBlock(w.docs, w.blockBuf, w.compressLevel)
 
 	if _, err := w.w.Write(w.blockBuf); err != nil {
 		return 0, err

--- a/frac/active_sealer_test.go
+++ b/frac/active_sealer_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/storage"
 )
 
 func TestDocBlocksWriter(t *testing.T) {
@@ -42,8 +42,8 @@ func TestDocBlocksWriter(t *testing.T) {
 			blockIndex, docOffset := pos.Unpack()
 			blockOffset := bw.BlockOffsets[blockIndex]
 
-			blockHeader := disk.DocBlock(docBlocks[blockOffset:])
-			block := disk.DocBlock(docBlocks[blockOffset : blockOffset+blockHeader.FullLen()])
+			blockHeader := storage.DocBlock(docBlocks[blockOffset:])
+			block := storage.DocBlock(docBlocks[blockOffset : blockOffset+blockHeader.FullLen()])
 
 			binDocs, err := block.DecompressTo(nil)
 			r.NoError(err)
@@ -67,8 +67,8 @@ func assertBlocks(t *testing.T, docBlocks []byte, numBlocks int) {
 	t.Helper()
 	var n int
 	for ; len(docBlocks) > 0; n++ {
-		header := disk.DocBlock(docBlocks[:disk.DocBlockHeaderLen])
-		docBlock := disk.DocBlock(docBlocks[:header.FullLen()])
+		header := storage.DocBlock(docBlocks[:storage.DocBlockHeaderLen])
+		docBlock := storage.DocBlock(docBlocks[:header.FullLen()])
 		_, err := docBlock.DecompressTo(nil)
 		require.NoError(t, err)
 		docBlocks = docBlocks[docBlock.FullLen():]

--- a/frac/active_writer.go
+++ b/frac/active_writer.go
@@ -3,8 +3,8 @@ package frac
 import (
 	"os"
 
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/metric/stopwatch"
+	"github.com/ozontech/seq-db/storage"
 )
 
 type ActiveWriter struct {
@@ -28,8 +28,8 @@ func (a *ActiveWriter) Write(docs, meta []byte, sw *stopwatch.Stopwatch) error {
 		return err
 	}
 
-	disk.DocBlock(meta).SetExt1(uint64(len(docs)))
-	disk.DocBlock(meta).SetExt2(uint64(offset))
+	storage.DocBlock(meta).SetExt1(uint64(len(docs)))
+	storage.DocBlock(meta).SetExt2(uint64(offset))
 
 	m = sw.Start("write_meta")
 	_, err = a.meta.Write(meta, sw)

--- a/frac/compress.go
+++ b/frac/compress.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	"github.com/ozontech/seq-db/disk"
+	"github.com/ozontech/seq-db/storage"
 	"github.com/ozontech/seq-db/util"
 )
 
@@ -23,8 +23,8 @@ type DocsMetasCompressor struct {
 	docsCompressLevel int
 	metaCompressLevel int
 
-	docsBuf disk.DocBlock
-	metaBuf disk.DocBlock
+	docsBuf storage.DocBlock
+	metaBuf storage.DocBlock
 }
 
 var compressorPool = sync.Pool{
@@ -50,9 +50,9 @@ func (c *DocsMetasCompressor) CompressDocsAndMetas(docs, meta []byte) {
 	c.metaBuf = initBuf(c.metaBuf, len(meta))
 
 	// Compress docs block.
-	c.docsBuf = disk.CompressDocBlock(docs, c.docsBuf, c.docsCompressLevel)
+	c.docsBuf = storage.CompressDocBlock(docs, c.docsBuf, c.docsCompressLevel)
 	// Compress metas block.
-	c.metaBuf = disk.CompressDocBlock(meta, c.metaBuf, c.metaCompressLevel)
+	c.metaBuf = storage.CompressDocBlock(meta, c.metaBuf, c.metaCompressLevel)
 	// Set compressed doc block size.
 	c.metaBuf.SetExt1(uint64(len(c.docsBuf)))
 

--- a/frac/doc_provider.go
+++ b/frac/doc_provider.go
@@ -8,8 +8,8 @@ import (
 	insaneJSON "github.com/ozontech/insane-json"
 
 	"github.com/ozontech/seq-db/consts"
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/storage"
 )
 
 type DocProvider struct {
@@ -60,7 +60,7 @@ func (dp *DocProvider) TryReset() {
 
 }
 
-func (dp *DocProvider) Provide() (disk.DocBlock, disk.DocBlock) {
+func (dp *DocProvider) Provide() (storage.DocBlock, storage.DocBlock) {
 	c := GetDocsMetasCompressor(-1, -1)
 	c.CompressDocsAndMetas(dp.Docs, dp.Metas)
 	return c.DocsMetas()

--- a/frac/info.go
+++ b/frac/info.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ozontech/seq-db/config"
 	"github.com/ozontech/seq-db/consts"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/storage"
 )
 
 const DistributionMaxInterval = 24 * time.Hour
@@ -37,6 +38,10 @@ type Info struct {
 	CreationTime uint64                `json:"creation_time"`
 	SealingTime  uint64                `json:"sealing_time"`
 	Distribution *seq.MIDsDistribution `json:"distribution"`
+
+	// StorageType specifies storage where fraction is located.
+	// For now it can be either local storage or S3 storage.
+	StorageType storage.Type `json:"storage_type"`
 }
 
 func NewInfo(filename string, docsOnDisk, metaOnDisk uint64) *Info {
@@ -52,6 +57,7 @@ func NewInfo(filename string, docsOnDisk, metaOnDisk uint64) *Info {
 		ConstLIDBlockCap:      consts.LIDBlockCap,
 		DocsOnDisk:            docsOnDisk,
 		MetaOnDisk:            metaOnDisk,
+		StorageType:           storage.TypeLocal,
 	}
 }
 

--- a/frac/sealed/lids/loader.go
+++ b/frac/sealed/lids/loader.go
@@ -2,7 +2,7 @@ package lids
 
 import (
 	"github.com/ozontech/seq-db/cache"
-	"github.com/ozontech/seq-db/disk"
+	"github.com/ozontech/seq-db/storage"
 )
 
 type UnpackBuffer struct {
@@ -15,12 +15,12 @@ type UnpackBuffer struct {
 // Use your own Loader instance for each search query
 type Loader struct {
 	cache     *cache.Cache[*Block]
-	reader    *disk.IndexReader
+	reader    *storage.IndexReader
 	unpackBuf *UnpackBuffer
 	blockBuf  []byte
 }
 
-func NewLoader(r *disk.IndexReader, c *cache.Cache[*Block]) *Loader {
+func NewLoader(r *storage.IndexReader, c *cache.Cache[*Block]) *Loader {
 	return &Loader{
 		cache:     c,
 		reader:    r,

--- a/frac/sealed/seqids/loader.go
+++ b/frac/sealed/seqids/loader.go
@@ -6,8 +6,8 @@ import (
 	"github.com/ozontech/seq-db/cache"
 	"github.com/ozontech/seq-db/config"
 	"github.com/ozontech/seq-db/consts"
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/storage"
 )
 
 type Table struct {
@@ -26,7 +26,7 @@ func (Table) BlockStartLID(blockIndex uint32) uint32 {
 }
 
 type Loader struct {
-	reader      *disk.IndexReader
+	reader      *storage.IndexReader
 	table       *Table
 	cacheMIDs   *cache.Cache[[]byte]
 	cacheRIDs   *cache.Cache[[]byte]

--- a/frac/sealed/seqids/provider.go
+++ b/frac/sealed/seqids/provider.go
@@ -3,8 +3,8 @@ package seqids
 import (
 	"github.com/ozontech/seq-db/cache"
 	"github.com/ozontech/seq-db/config"
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/storage"
 )
 
 type Provider struct {
@@ -16,7 +16,7 @@ type Provider struct {
 }
 
 func NewProvider(
-	indexReader *disk.IndexReader,
+	indexReader *storage.IndexReader,
 	cacheMIDs *cache.Cache[[]byte],
 	cacheRIDs *cache.Cache[[]byte],
 	cacheParams *cache.Cache[BlockParams],

--- a/frac/sealed/token/block_loader.go
+++ b/frac/sealed/token/block_loader.go
@@ -9,8 +9,8 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ozontech/seq-db/cache"
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/logger"
+	"github.com/ozontech/seq-db/storage"
 )
 
 const sizeOfUint32 = uint32(unsafe.Sizeof(uint32(0)))
@@ -66,10 +66,10 @@ func (b *Block) GetToken(index int) []byte {
 type BlockLoader struct {
 	fracName string
 	cache    *cache.Cache[*Block]
-	reader   *disk.IndexReader
+	reader   *storage.IndexReader
 }
 
-func NewBlockLoader(fracName string, reader *disk.IndexReader, c *cache.Cache[*Block]) *BlockLoader {
+func NewBlockLoader(fracName string, reader *storage.IndexReader, c *cache.Cache[*Block]) *BlockLoader {
 	return &BlockLoader{
 		fracName: fracName,
 		cache:    c,

--- a/frac/sealed/token/table_loader.go
+++ b/frac/sealed/token/table_loader.go
@@ -6,22 +6,22 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ozontech/seq-db/cache"
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/logger"
 	"github.com/ozontech/seq-db/packer"
+	"github.com/ozontech/seq-db/storage"
 )
 
 const CacheKeyTable = 1
 
 type TableLoader struct {
 	fracName string
-	reader   *disk.IndexReader
+	reader   *storage.IndexReader
 	cache    *cache.Cache[Table]
 	i        uint32
 	buf      []byte
 }
 
-func NewTableLoader(fracName string, reader *disk.IndexReader, c *cache.Cache[Table]) *TableLoader {
+func NewTableLoader(fracName string, reader *storage.IndexReader, c *cache.Cache[Table]) *TableLoader {
 	return &TableLoader{
 		fracName: fracName,
 		reader:   reader,
@@ -70,7 +70,7 @@ func TableFromBlocks(blocks []TableBlock) Table {
 	return table
 }
 
-func (l *TableLoader) readHeader() disk.IndexBlockHeader {
+func (l *TableLoader) readHeader() storage.IndexBlockHeader {
 	h, e := l.reader.GetBlockHeader(l.i)
 	if e != nil {
 		logger.Panic("error reading block header", zap.Error(e))

--- a/frac/sealed_index.go
+++ b/frac/sealed_index.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/zap"
 
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/frac/processor"
 	"github.com/ozontech/seq-db/frac/sealed/lids"
 	"github.com/ozontech/seq-db/frac/sealed/seqids"
@@ -21,6 +20,7 @@ import (
 	"github.com/ozontech/seq-db/parser"
 	"github.com/ozontech/seq-db/pattern"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/storage"
 	"github.com/ozontech/seq-db/util"
 )
 
@@ -67,7 +67,7 @@ type sealedDataProvider struct {
 	tokenTableLoader *token.TableLoader
 
 	blocksOffsets []uint64
-	docsReader    *disk.DocsReader
+	docsReader    *storage.DocsReader
 }
 
 func (dp *sealedDataProvider) getIDsIndex() *sealedIDsIndex {
@@ -279,7 +279,7 @@ func (ti *sealedTokenIndex) GetLIDsFromTIDs(tids []uint32, stats lids.Counter, m
 
 type sealedFetchIndex struct {
 	idsIndex      *sealedIDsIndex
-	docsReader    *disk.DocsReader
+	docsReader    *storage.DocsReader
 	blocksOffsets []uint64
 }
 

--- a/frac/sealed_loader.go
+++ b/frac/sealed_loader.go
@@ -5,16 +5,16 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/frac/sealed/lids"
 	"github.com/ozontech/seq-db/frac/sealed/seqids"
 	"github.com/ozontech/seq-db/logger"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/storage"
 	"github.com/ozontech/seq-db/util"
 )
 
 type Loader struct {
-	reader     *disk.IndexReader
+	reader     *storage.IndexReader
 	blockIndex uint32
 	blockBuf   []byte
 }
@@ -61,7 +61,7 @@ func (l *Loader) nextIndexBlock() ([]byte, error) {
 	return data, err
 }
 
-func (l *Loader) skipBlock() disk.IndexBlockHeader {
+func (l *Loader) skipBlock() storage.IndexBlockHeader {
 	header, err := l.reader.GetBlockHeader(l.blockIndex)
 	if err != nil {
 		logger.Panic("error reading block header", zap.Error(err))

--- a/fracmanager/fracmanager.go
+++ b/fracmanager/fracmanager.go
@@ -18,10 +18,10 @@ import (
 
 	"github.com/ozontech/seq-db/config"
 	"github.com/ozontech/seq-db/consts"
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/frac"
 	"github.com/ozontech/seq-db/logger"
 	"github.com/ozontech/seq-db/metric"
+	"github.com/ozontech/seq-db/storage"
 	"github.com/ozontech/seq-db/util"
 )
 
@@ -341,7 +341,7 @@ func (fm *FracManager) replayAll(ctx context.Context, actives []*frac.Active) er
 	return nil
 }
 
-func (fm *FracManager) Append(ctx context.Context, docs, metas disk.DocBlock) error {
+func (fm *FracManager) Append(ctx context.Context, docs, metas storage.DocBlock) error {
 	var err error
 	for {
 		select {

--- a/fracmanager/fraction_provider.go
+++ b/fracmanager/fraction_provider.go
@@ -4,8 +4,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/frac"
+	"github.com/ozontech/seq-db/storage"
 )
 
 var storeBytesRead = promauto.NewCounter(prometheus.CounterOpts{
@@ -18,7 +18,7 @@ type fractionProvider struct {
 	config        *frac.Config
 	cacheProvider *CacheMaintainer
 	activeIndexer *frac.ActiveIndexer
-	readLimiter   *disk.ReadLimiter
+	readLimiter   *storage.ReadLimiter
 }
 
 func newFractionProvider(c *frac.Config, cp *CacheMaintainer, readerWorkers, indexWorkers int) *fractionProvider {
@@ -29,7 +29,7 @@ func newFractionProvider(c *frac.Config, cp *CacheMaintainer, readerWorkers, ind
 		config:        c,
 		cacheProvider: cp,
 		activeIndexer: ai,
-		readLimiter:   disk.NewReadLimiter(readerWorkers, storeBytesRead),
+		readLimiter:   storage.NewReadLimiter(readerWorkers, storeBytesRead),
 	}
 }
 

--- a/fracmanager/proxy_frac.go
+++ b/fracmanager/proxy_frac.go
@@ -33,6 +33,10 @@ var ErrSealingFractionSuicided = errors.New("sealing fraction is suicided")
  *  All other states are impossible.
  */
 
+var (
+	_ frac.Fraction = (*proxyFrac)(nil)
+)
+
 type proxyFrac struct {
 	fp *fractionProvider
 

--- a/proxy/bulk/ingestor_test.go
+++ b/proxy/bulk/ingestor_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ozontech/seq-db/consts"
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/frac"
 	"github.com/ozontech/seq-db/mappingprovider"
 	"github.com/ozontech/seq-db/packer"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/storage"
 )
 
 func TestProcessDocuments(t *testing.T) {
@@ -420,7 +420,7 @@ func TestProcessDocuments(t *testing.T) {
 			r.Equal(len(payload.InDocs), total)
 			r.Equal(len(payload.InDocs), c.total)
 
-			binaryDocs, err := disk.DocBlock(c.docs).DecompressTo(nil)
+			binaryDocs, err := storage.DocBlock(c.docs).DecompressTo(nil)
 			require.NoError(t, err)
 
 			docsUnpacker := packer.NewBytesUnpacker(binaryDocs)
@@ -429,7 +429,7 @@ func TestProcessDocuments(t *testing.T) {
 				gotDocs = append(gotDocs, docsUnpacker.GetBinary())
 			}
 
-			binaryMetas, err := disk.DocBlock(c.metas).DecompressTo(nil)
+			binaryMetas, err := storage.DocBlock(c.metas).DecompressTo(nil)
 			require.NoError(t, err)
 			metasUnpacker := packer.NewBytesUnpacker(binaryMetas)
 			var gotMetas []frac.MetaData

--- a/proxy/search/streaming_doc.go
+++ b/proxy/search/streaming_doc.go
@@ -1,8 +1,8 @@
 package search
 
 import (
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/storage"
 )
 
 type StreamingDoc struct {
@@ -28,7 +28,7 @@ func NewStreamingDoc(idSource seq.IDSource, data []byte) StreamingDoc {
 }
 
 func unpackDoc(data []byte, source uint64) StreamingDoc {
-	block := disk.DocBlock(data)
+	block := storage.DocBlock(data)
 	doc := StreamingDoc{
 		ID: seq.ID{
 			MID: seq.MID(block.GetExt1()),

--- a/storage/block_former.go
+++ b/storage/block_former.go
@@ -1,5 +1,5 @@
 // Package disk implements read write fraction routines
-package disk
+package storage
 
 import (
 	"time"

--- a/storage/blocks_stats.go
+++ b/storage/blocks_stats.go
@@ -1,4 +1,4 @@
-package disk
+package storage
 
 import (
 	"time"

--- a/storage/blocks_writer.go
+++ b/storage/blocks_writer.go
@@ -1,4 +1,4 @@
-package disk
+package storage
 
 import (
 	"encoding/binary"

--- a/storage/codec.go
+++ b/storage/codec.go
@@ -1,4 +1,4 @@
-package disk
+package storage
 
 import (
 	"fmt"

--- a/storage/doc_block.go
+++ b/storage/doc_block.go
@@ -1,4 +1,4 @@
-package disk
+package storage
 
 import (
 	"encoding/binary"

--- a/storage/docs_reader.go
+++ b/storage/docs_reader.go
@@ -1,9 +1,9 @@
-package disk
+package storage
 
 import (
 	"encoding/binary"
 	"fmt"
-	"os"
+	"io"
 
 	"github.com/ozontech/seq-db/cache"
 )
@@ -13,9 +13,9 @@ type DocsReader struct {
 	cache  *cache.Cache[[]byte]
 }
 
-func NewDocsReader(reader *ReadLimiter, file *os.File, docsCache *cache.Cache[[]byte]) DocsReader {
+func NewDocsReader(limiter *ReadLimiter, reader io.ReaderAt, docsCache *cache.Cache[[]byte]) DocsReader {
 	return DocsReader{
-		reader: NewDocBlocksReader(reader, file),
+		reader: NewDocBlocksReader(limiter, reader),
 		cache:  docsCache,
 	}
 }

--- a/storage/index_block_header.go
+++ b/storage/index_block_header.go
@@ -1,4 +1,4 @@
-package disk
+package storage
 
 import "encoding/binary"
 

--- a/storage/index_reader.go
+++ b/storage/index_reader.go
@@ -1,10 +1,9 @@
-package disk
+package storage
 
 import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/ozontech/seq-db/bytespool"
 	"github.com/ozontech/seq-db/cache"
@@ -13,15 +12,22 @@ import (
 
 type IndexReader struct {
 	limiter *ReadLimiter
-	file    *os.File
-	cache   *cache.Cache[[]byte]
+
+	reader     io.ReaderAt
+	readerName string
+
+	cache *cache.Cache[[]byte]
 }
 
-func NewIndexReader(reader *ReadLimiter, file *os.File, registryCache *cache.Cache[[]byte]) IndexReader {
+func NewIndexReader(
+	limiter *ReadLimiter, readerName string,
+	reader io.ReaderAt, registryCache *cache.Cache[[]byte],
+) IndexReader {
 	return IndexReader{
-		limiter: reader,
-		file:    file,
-		cache:   registryCache,
+		limiter:    limiter,
+		reader:     reader,
+		readerName: readerName,
+		cache:      registryCache,
 	}
 }
 
@@ -33,14 +39,14 @@ func (r *IndexReader) GetBlockHeader(index uint32) (IndexBlockHeader, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if (uint64(index)+1)*IndexBlockHeaderSize > uint64(len(registry)) {
 		return nil, fmt.Errorf(
 			"too large index block in file %s, with index %d, registry size %d",
-			r.file.Name(),
-			index,
-			len(registry),
+			r.readerName, index, len(registry),
 		)
 	}
+
 	pos := index * IndexBlockHeaderSize
 	return registry[pos : pos+IndexBlockHeaderSize], nil
 }
@@ -48,7 +54,7 @@ func (r *IndexReader) GetBlockHeader(index uint32) (IndexBlockHeader, error) {
 func (r *IndexReader) readRegistry() ([]byte, error) {
 	numBuf := make([]byte, 16)
 
-	n, err := r.limiter.ReadAt(r.file, numBuf, 0)
+	n, err := r.limiter.ReadAt(r.reader, numBuf, 0)
 	if err != nil {
 		return nil, fmt.Errorf("can't read disk registry, %s", err.Error())
 	}
@@ -60,7 +66,7 @@ func (r *IndexReader) readRegistry() ([]byte, error) {
 	l := binary.LittleEndian.Uint64(numBuf[8:])
 	buf := make([]byte, l)
 
-	n, err = r.limiter.ReadAt(r.file, buf, int64(pos))
+	n, err = r.limiter.ReadAt(r.reader, buf, int64(pos))
 	if err != nil && err != io.EOF {
 		return nil, fmt.Errorf("can't read disk registry, %s", err.Error())
 	}
@@ -84,14 +90,14 @@ func (r *IndexReader) ReadIndexBlock(blockIndex uint32, dst []byte) ([]byte, uin
 
 	if header.Codec() == CodecNo {
 		dst = util.EnsureSliceSize(dst, int(header.Len()))
-		n, err := r.limiter.ReadAt(r.file, dst, int64(header.GetPos()))
+		n, err := r.limiter.ReadAt(r.reader, dst, int64(header.GetPos()))
 		return dst, uint64(n), err
 	}
 
 	buf := bytespool.AcquireLen(int(header.Len()))
 	defer bytespool.Release(buf)
 
-	n, err := r.limiter.ReadAt(r.file, buf.B, int64(header.GetPos()))
+	n, err := r.limiter.ReadAt(r.reader, buf.B, int64(header.GetPos()))
 	if err != nil {
 		return nil, uint64(n), err
 	}

--- a/storage/io.go
+++ b/storage/io.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"context"
+	"io"
+	"os"
+)
+
+type Type string
+
+const (
+	TypeLocal  Type = "local"
+	TypeRemote Type = "remote"
+)
+
+type ImmutableFile interface {
+	Name() string
+	Stat() (os.FileInfo, error)
+
+	io.Reader
+	io.ReaderAt
+
+	io.Seeker
+	io.Closer
+}
+
+type Uploader interface {
+	Upload(context.Context, ImmutableFile) error
+}

--- a/storage/read_limiter.go
+++ b/storage/read_limiter.go
@@ -1,7 +1,7 @@
-package disk
+package storage
 
 import (
-	"os"
+	"io"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -18,13 +18,13 @@ func NewReadLimiter(maxReadsNum int, counter prometheus.Counter) *ReadLimiter {
 	}
 }
 
-func (r *ReadLimiter) ReadAt(f *os.File, buf []byte, offset int64) (int, error) {
-	r.sem <- struct{}{}
-	n, err := f.ReadAt(buf, offset)
-	<-r.sem
+func (rl *ReadLimiter) ReadAt(r io.ReaderAt, buf []byte, offset int64) (int, error) {
+	rl.sem <- struct{}{}
+	n, err := r.ReadAt(buf, offset)
+	<-rl.sem
 
-	if r.metric != nil {
-		r.metric.Add(float64(n))
+	if rl.metric != nil {
+		rl.metric.Add(float64(n))
 	}
 	return n, err
 }

--- a/storeapi/grpc_fetch.go
+++ b/storeapi/grpc_fetch.go
@@ -12,11 +12,11 @@ import (
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
 
-	"github.com/ozontech/seq-db/disk"
 	"github.com/ozontech/seq-db/logger"
 	"github.com/ozontech/seq-db/metric"
 	"github.com/ozontech/seq-db/pkg/storeapi"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/storage"
 	"github.com/ozontech/seq-db/tracing"
 	"github.com/ozontech/seq-db/util"
 )
@@ -88,8 +88,8 @@ func (g *GrpcV1) doFetch(ctx context.Context, req *storeapi.FetchRequest, stream
 
 		sendTime := time.Now()
 
-		buf = util.EnsureSliceSize(buf, disk.DocBlockHeaderLen+len(doc))
-		block := disk.PackDocBlock(doc, buf)
+		buf = util.EnsureSliceSize(buf, storage.DocBlockHeaderLen+len(doc))
+		block := storage.PackDocBlock(doc, buf)
 		block.SetExt1(uint64(id.ID.MID))
 		block.SetExt2(uint64(id.ID.RID))
 
@@ -167,7 +167,7 @@ func releaseDocFieldsFilter(dp *docFieldsFilter) {
 
 // FilterDocFields filters document with dp.filter.
 // This function doesn't mutate the given doc slice.
-func (dp *docFieldsFilter) FilterDocFields(doc []byte) disk.DocBlock {
+func (dp *docFieldsFilter) FilterDocFields(doc []byte) storage.DocBlock {
 	doc = dp.filterFields(doc)
 	return doc
 }


### PR DESCRIPTION
Since we can have different storage backends (like local FS, S3, etc.), this change will make code easier to maintain in the future.

This is the first commit in the series of commits (#38)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced legacy disk-specific backend with a generic storage layer to support multiple storage backends (local/remote) and generic readers.
  * Public types and constructors updated to accept storage abstractions; added storage type indicator and read-only/upload interfaces.

* **Performance / Chores**
  * Sealed-fraction cache now tracks versions to persist only when changed, reducing unnecessary disk writes.

* **Style / Documentation**
  * Improved log messages and comments for clarity (e.g., "frac-cache").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->