### PR TITLE
docs: add documentation for timeseries

### DIFF
--- a/docs/en/10-public-api.md
+++ b/docs/en/10-public-api.md
@@ -448,12 +448,12 @@ Sample documents:
   "query": {
     "from": "2000-01-01T00:00:00Z",
     "to": "2077-01-01T00:00:00Z",
-    "query":"*",
+    "query":"*"
   },
   "aggs": [
     {
       "func": "AGG_FUNC_COUNT",
-      "group_by": "service"
+      "group_by": "service",
       "interval": "30s"
     }
   ]

--- a/docs/ru/10-public-api.md
+++ b/docs/ru/10-public-api.md
@@ -443,26 +443,26 @@ we get
 
 ##### COUNT (с указанием интервала)
 
-**Request:**
+**Запрос:**
 
 ```sh
 {
   "query": {
     "from": "2000-01-01T00:00:00Z",
     "to": "2077-01-01T00:00:00Z",
-    "query":"*",
+    "query":"*"
   },
   "aggs": [
     {
       "func": "AGG_FUNC_COUNT",
-      "group_by": "service"
+      "group_by": "service",
       "interval": "30s"
     }
   ]
 } | grpcurl -plaintext -d @ localhost:9004 seqproxyapi.v1.SeqProxyApi/GetAggregation
 ```
 
-**Response:**
+**Ответ:**
 
 ```json
 {


### PR DESCRIPTION
Closes #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Documented time-interval (timeseries) support in GetAggregation, showing how aggregations compute statistics within intervals.
  - Clarified that UNIQUE aggregation is not supported for timeseries calculations.
  - Added two COUNT (with interval) request/response examples demonstrating time-bucketed counts with per-bucket timestamps and group_by keys (placed in two locations for discoverability).
  - Minor formatting cleanup (trailing newline).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->