### PR TITLE
chore: skip `.remote` fraction files

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -61,6 +61,8 @@ const (
 	IndexTmpFileSuffix = "._index"
 	IndexDelFileSuffix = ".index.del"
 
+	RemoteFractionSuffix = ".remote"
+
 	FracCacheFileSuffix = ".frac-cache"
 
 	// tracing

--- a/fracmanager/loader.go
+++ b/fracmanager/loader.go
@@ -185,6 +185,12 @@ func (l *loader) makeInfos(files []string) ([]string, map[string]*fracInfo) {
 			continue
 		}
 
+		// TODO(dkharms): Remove this condition in the following PR.
+		// https://github.com/ozontech/seq-db/pull/60/
+		if suffix == consts.RemoteFractionSuffix {
+			continue
+		}
+
 		info, ok := infos[fracID]
 		if !ok {
 			info = &fracInfo{base: base}


### PR DESCRIPTION
It's safe point to be able to roll back changes from following PRs that introduce support for offloading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote fraction files (with the “.remote” suffix) are now excluded from loading and display, preventing unintended processing and reducing noise.
* **Chores**
  * Standardized the “.remote” suffix via a new constant for consistent handling across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->