### PR TITLE
build: add seq-ui docker-compose

### DIFF
--- a/quickstart/config.seq-ui.yaml
+++ b/quickstart/config.seq-ui.yaml
@@ -1,0 +1,24 @@
+server:
+  http_addr: "0.0.0.0:5555"
+  grpc_addr: "0.0.0.0:5556"
+  debug_addr: "0.0.0.0:5557"
+clients:
+  seq_db_addrs:
+    - "seq-db-proxy:9004"
+  seq_db_timeout: 15s
+  seq_db_avg_doc_size: 100
+  request_retries: 3
+  proxy_client_mode: "grpc"
+  grpc_keepalive_params:
+    time: 10s
+    timeout: 10s
+    permit_without_stream: true
+handlers:
+  seq_api:
+    seq_cli_max_search_limit: 10000
+    max_search_limit: 1000
+    max_search_total_limit: 100000
+    max_search_offset_limit: 100000
+    max_export_limit: 10000
+    max_parallel_export_requests: 1
+    max_aggregations_per_request: 3

--- a/quickstart/docker-compose.seq-ui.yaml
+++ b/quickstart/docker-compose.seq-ui.yaml
@@ -1,4 +1,14 @@
 services:
+  seq-ui:
+    image: ghcr.io/ozontech/seq-ui:latest
+    volumes:
+      - ./config.seq-ui.yaml:/seq-ui/config.yaml
+    ports:
+      - "5555:5555" # Default HTTP port
+      - "5556:5556" # Default gRPC port
+      - "5557:5557" # Default debug port
+    command: --config config.yaml
+  
   seq-db-proxy:
     build:
       context: ../


### PR DESCRIPTION
# Description

Add docker-compose file to launch seq-db alongside seq-ui


---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a ready-to-run docker-compose stack for Seq UI (UI, DB proxy, DB store, and MinIO) to simplify local setup.
  * Added a default configuration enabling connectivity, timeouts, keepalive, and sensible limits for search, export, and aggregations.

* **Chores**
  * Updated MinIO image to minio/minio:latest in quickstart to ensure compatibility and latest fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->