### PR TITLE
build: use ghcr images in quickstart docker compose files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ cover.out
 junit.xml
 /go.work*
 /data
+/quickstart/data
 .immature

--- a/quickstart/config.quickstart.yaml
+++ b/quickstart/config.quickstart.yaml
@@ -29,4 +29,4 @@ slow_logs:
   fetch_threshold: 20ms
 
 mapping:
-  path: /seq-db/mappings/logging-new.yaml
+  path: /seq-db/mappings.yaml

--- a/quickstart/docker-compose.seq-ui.yaml
+++ b/quickstart/docker-compose.seq-ui.yaml
@@ -8,14 +8,12 @@ services:
       - "5556:5556" # Default gRPC port
       - "5557:5557" # Default debug port
     command: --config config.yaml
-  
+
   seq-db-proxy:
-    build:
-      context: ../
-      dockerfile: build/package/Dockerfile
+    image: ghcr.io/ozontech/seq-db:latest
     volumes:
       - "./config.quickstart.yaml:/seq-db/config.yaml"
-      - "../tests/data/mappings/:/seq-db/mappings/"
+      - "./mappings.yaml:/seq-db/mappings.yaml"
     ports:
       - "9002:9002" # Default HTTP port
       - "9004:9004" # Default gRPC port
@@ -23,15 +21,13 @@ services:
     command: --mode proxy --config=config.yaml
     depends_on:
       - seq-db-store
-  
+
   seq-db-store:
-    build:
-      context: ../
-      dockerfile: build/package/Dockerfile
+    image: ghcr.io/ozontech/seq-db:latest
     volumes:
       - "./config.quickstart.yaml:/seq-db/config.yaml"
-      - "../data/:/seq-db/data/"
-      - "../tests/data/mappings/:/seq-db/mappings/"
+      - "./data/:/seq-db/data/"
+      - "./mappings.yaml:/seq-db/mappings.yaml"
     command: --mode store --config=config.yaml
 
   minio:

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -1,11 +1,9 @@
 services:
   seq-db-proxy:
-    build:
-      context: ../
-      dockerfile: build/package/Dockerfile
+    image: ghcr.io/ozontech/seq-db:latest
     volumes:
       - "./config.quickstart.yaml:/seq-db/config.yaml"
-      - "../tests/data/mappings/:/seq-db/mappings/"
+      - "./mappings.yaml:/seq-db/mappings.yaml"
     ports:
       - "9002:9002" # Default HTTP port
       - "9004:9004" # Default gRPC port
@@ -13,15 +11,13 @@ services:
     command: --mode proxy --config=config.yaml
     depends_on:
       - seq-db-store
-  
+
   seq-db-store:
-    build:
-      context: ../
-      dockerfile: build/package/Dockerfile
+    image: ghcr.io/ozontech/seq-db:latest
     volumes:
       - "./config.quickstart.yaml:/seq-db/config.yaml"
-      - "../data/:/seq-db/data/"
-      - "../tests/data/mappings/:/seq-db/mappings/"
+      - "./data/:/seq-db/data/"
+      - "./mappings.yaml:/seq-db/mappings.yaml"
     command: --mode store --config=config.yaml
 
   minio:

--- a/quickstart/mappings.yaml
+++ b/quickstart/mappings.yaml
@@ -1,0 +1,24 @@
+mapping-list:
+  - type: "keyword"
+    name: "k8s_pod"
+  - type: "keyword"
+    name: "k8s_namespace"
+  - type: "keyword"
+    name: "k8s_container"
+  - type: "text"
+    name: "request"
+  - type: "path"
+    name: "request_uri"
+  - name: "message"
+    types:
+      - type: "text"
+      - title: "keyword"
+        type: "keyword"
+        size: 18
+  - type: "object"
+    name: "someobj"
+    mapping-list:
+      - type: "keyword"
+        name: "nested"
+      - type:  "text"
+        name: "nestedtext"


### PR DESCRIPTION
# Description

use ghcr images in quickstart docker compose files

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default quickstart/mappings.yaml with predefined field mappings to simplify setup and customization.

* **Chores**
  * Quickstart now uses published images (ghcr.io/ozontech/seq-db:latest) instead of local builds.
  * Updated docker-compose volumes to use local ./data and a single ./mappings.yaml file.
  * Config updated to reference the new mappings.yaml path.
  * .gitignore now excludes /quickstart/data to prevent accidental commits of local data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->