### PR TITLE
build: remove offloading form quickstart

### DIFF
--- a/quickstart/config.quickstart.yaml
+++ b/quickstart/config.quickstart.yaml
@@ -15,18 +15,8 @@ cluster:
   hot_stores:
     - seq-db-store:9004
 
-offloading:
-  enabled: true
-  retention: 5m
-  endpoint: http://minio:9000/
-  bucket: remote-storage
-  access_key: minioadmin
-  secret_key: minioadmin
-
 slow_logs:
-  bulk_threshold: 100ms
-  search_threshold: 20ms
-  fetch_threshold: 20ms
+  bulk_threshold: 1s
 
 mapping:
   path: /seq-db/mappings.yaml

--- a/quickstart/config.seq-ui.yaml
+++ b/quickstart/config.seq-ui.yaml
@@ -6,19 +6,6 @@ clients:
   seq_db_addrs:
     - "seq-db-proxy:9004"
   seq_db_timeout: 15s
-  seq_db_avg_doc_size: 100
-  request_retries: 3
-  proxy_client_mode: "grpc"
-  grpc_keepalive_params:
-    time: 10s
-    timeout: 10s
-    permit_without_stream: true
 handlers:
   seq_api:
-    seq_cli_max_search_limit: 10000
-    max_search_limit: 1000
-    max_search_total_limit: 100000
-    max_search_offset_limit: 100000
-    max_export_limit: 10000
-    max_parallel_export_requests: 1
-    max_aggregations_per_request: 3
+    max_search_limit: 100

--- a/quickstart/docker-compose.seq-ui.yaml
+++ b/quickstart/docker-compose.seq-ui.yaml
@@ -29,13 +29,3 @@ services:
       - "./data/:/seq-db/data/"
       - "./mappings.yaml:/seq-db/mappings.yaml"
     command: --mode store --config=config.yaml
-
-  minio:
-    image: minio/minio:latest
-    environment:
-      - MINIO_ROOT_USER=minioadmin
-      - MINIO_ROOT_PASSWORD=minioadmin
-    ports:
-      - "9000:9000"
-      - "9001:9001"
-    command: server /data --console-address ":9001"

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -19,13 +19,3 @@ services:
       - "./data/:/seq-db/data/"
       - "./mappings.yaml:/seq-db/mappings.yaml"
     command: --mode store --config=config.yaml
-
-  minio:
-    image: minio/minio:latest
-    environment:
-      - MINIO_ROOT_USER=minioadmin
-      - MINIO_ROOT_PASSWORD=minioadmin
-    ports:
-      - "9000:9000"
-      - "9001:9001"
-    command: server /data --console-address ":9001"


### PR DESCRIPTION
# Description

remove offloading form quickstart

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Removed bundled MinIO service from quickstart stacks; local setups no longer include object storage.
  - Removed offloading/remote-storage configuration from the quickstart config.

- Refactor
  - Simplified slow-log settings to a single bulk threshold set to 1s.

- Chores
  - Reduced default search limits to 100 and removed several client retry/keepalive and export/aggregation configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->