### PR TITLE
docs: update quickstart docs

### DIFF
--- a/docs/en/01-quickstart.md
+++ b/docs/en/01-quickstart.md
@@ -146,7 +146,7 @@ curl --request POST   \
 
 seq-ui is a backend for user interface.
 
-To launch seq-db with seq-ui you need to add minimal configuration file for seq-ui, config.seq-ui.yaml:
+To launch seq-db with seq-ui you need to add minimal configuration file for seq-ui, [config.seq-ui.yaml](https://github.com/ozontech/seq-db/blob/main/quickstart/config.seq-ui.yaml):
 
 ```yaml
 server:
@@ -186,7 +186,7 @@ mapping:
   path: auto
 ```
 
-And then launch using this minimal docker compose example:
+And then launch using this minimal [docker compose example](https://github.com/ozontech/seq-db/blob/main/quickstart/docker-compose.seq-ui.yaml):
 
 ```yaml
 services:
@@ -200,6 +200,11 @@ services:
       - "5556:5556" # Default gRPC port
       - "5557:5557" # Default debug port
     command: --config config.yaml
+
+  seq-ui-fe:
+    image: ghcr.io/ozontech/seq-ui-fe:latest
+    ports:
+      - "5173:80"
   
   seq-db-proxy:
     image: ghcr.io/ozontech/seq-db:latest

--- a/docs/ru/01-quickstart.md
+++ b/docs/ru/01-quickstart.md
@@ -143,7 +143,7 @@ curl --request POST   \
 
 seq-ui это бэкенд для пользовательского интерфейса.
 
-Чтобы запустить seq-db в связке с seq-ui, нужно создать файл конфигурации для seq-ui, config.seq-ui.yaml:
+Чтобы запустить seq-db в связке с seq-ui, нужно создать файл конфигурации для seq-ui, [config.seq-ui.yaml](https://github.com/ozontech/seq-db/blob/main/quickstart/config.seq-ui.yaml):
 
 ```yaml
 server:
@@ -183,7 +183,7 @@ mapping:
   path: auto
 ```
 
-Далее нужно запустить этот docker compose пример:
+Далее нужно запустить этот [docker compose пример](https://github.com/ozontech/seq-db/blob/main/quickstart/docker-compose.seq-ui.yaml):
 
 ```yaml
 services:
@@ -197,6 +197,11 @@ services:
       - "5556:5556" # Default gRPC port
       - "5557:5557" # Default debug port
     command: --config config.yaml
+  
+  seq-ui-fe:
+    image: ghcr.io/ozontech/seq-ui-fe:latest
+    ports:
+      - "5173:80"
   
   seq-db-proxy:
     image: ghcr.io/ozontech/seq-db:latest


### PR DESCRIPTION
# Description

Update for quickstart docs.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated Quickstart (EN and RU) with direct links to hosted configuration and docker-compose resources.
  - Added an example frontend service (seq-ui-fe) to the docker-compose snippet, including default image and port mapping 5173:80.
  - Clarified instructions for running seq-db alongside seq-ui by referencing online configs instead of local files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->