### PR TITLE
docs: fix quickstart in 01-quickstart.md

### DIFF
--- a/docs/en/01-quickstart.md
+++ b/docs/en/01-quickstart.md
@@ -22,9 +22,6 @@ Before launch you need to create a config file:
 config.yaml:
 
 ```yaml
-storage:
-  data_dir: /seq-db-data
-
 mapping:
   path: auto
 ```

--- a/docs/ru/01-quickstart.md
+++ b/docs/ru/01-quickstart.md
@@ -22,9 +22,6 @@ seq-db можно быстро запустить в docker-контейнере
 config.yaml:
 
 ```yaml
-storage:
-  data_dir: /seq-db-data
-
 mapping:
   path: auto
 ```


### PR DESCRIPTION
# Description

Currently, the simplest quickstart doesn't work, since `/seq-db-data` doesn't exist inside the container. We can either:
-  simply omit the config for the data directory, since it's the first what a potential user will do and having a simpler config might be a good idea
- create volume and map a local directory to `/seq-db-data`:
```
docker run --rm \
  -p 9002:9002 \
  -p 9004:9004 \
  -p 9200:9200 \
  -v "$(pwd)"/config.yaml:/seq-db/config.yaml \
  -v "$(pwd)"/data:/seq-db-data \
  -it ghcr.io/ozontech/seq-db:latest --mode single --config=config.yaml
```

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quickstart guides (EN and RU) to simplify the sample config.yaml: removed the storage.data_dir line from the storage block; mapping.path: auto remains.
  * Aligns examples with current defaults to reduce setup confusion and streamline initial configuration.
  * Clarifies that users don’t need to specify data_dir in the basic example.
  * No functional changes to the product; existing configurations are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->