### PR TITLE
ci: run tests with race detector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           GOFLAGS: ${{ matrix.flags }}
           LOG_LEVEL: error
-        run: go test -short -coverprofile=profile${{ matrix.flags }}.out -covermode=atomic -coverpkg=./... ./...
+        run: go test -timeout=30m -short -coverprofile=profile${{ matrix.flags }}.out -covermode=atomic -coverpkg=./... ./...
 
       - name: Strip generated files from coverage
         run: |
@@ -61,9 +61,7 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: coverage
-          path: |
-            profile.out.clean
-            profile-race.out.clean
+          path: profile${{ matrix.flags }}.out.clean
           if-no-files-found: error
           retention-days: 1
 


### PR DESCRIPTION
# Description

Add job to run test with built-in Golang race detector.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
