### PR TITLE
fix(async search): fix search request aggs formatting

### DIFF
--- a/proxyapi/grpc_async_search.go
+++ b/proxyapi/grpc_async_search.go
@@ -164,12 +164,20 @@ func (g *grpcV1) DeleteAsyncSearch(
 func makeProtoRequestAggregations(sourceAggs []search.AggQuery) []*seqproxyapi.AggQuery {
 	aggs := make([]*seqproxyapi.AggQuery, 0, len(sourceAggs))
 	for _, agg := range sourceAggs {
-		aggs = append(aggs, &seqproxyapi.AggQuery{
+		agg := &seqproxyapi.AggQuery{
 			Field:     agg.Field,
 			GroupBy:   agg.GroupBy,
 			Func:      seqproxyapi.AggFunc(agg.Func),
 			Quantiles: agg.Quantiles,
-		})
+		}
+
+		// Support legacy format in which field means groupBy.
+		if agg.Func == seq.AggFuncCount && agg.GroupBy != "" {
+			agg.Field = agg.GroupBy
+			agg.GroupBy = ""
+		}
+
+		aggs = append(aggs, agg)
 	}
 	return aggs
 }

--- a/proxyapi/grpc_async_search.go
+++ b/proxyapi/grpc_async_search.go
@@ -26,6 +26,11 @@ func (g *grpcV1) StartAsyncSearch(
 			r.Size, g.config.AsyncSearchMaxDocumentsPerRequest)
 	}
 
+	// reject "empty" request: no docs, no aggs, no hist
+	if r.WithDocs == false && len(r.Aggs) == 0 && r.Hist == nil {
+		return nil, status.Error(codes.InvalidArgument, "can't serve empty request: fill aggs, hist or withDocs")
+	}
+
 	aggs, err := convertAggsQuery(r.Aggs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

fixed search request's aggs field formatting for FetchAsycnSearchResult and GetAsyncSearchesList methods

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
