### PR TITLE
ci: tweak `-count` option for benchmarks

### DIFF
--- a/.github/workflows/continuous-benchmarks.yml
+++ b/.github/workflows/continuous-benchmarks.yml
@@ -27,7 +27,9 @@ jobs:
 
       - name: Run Golang benchmarks
         shell: bash
-        run: LOG_LEVEL=FATAL go test -run='$^' -count=5 -bench=. -benchmem ./... | tee ${{ runner.temp }}/gotool.txt
+        run: |
+          COUNT=$([[ "${{ github.event_name }}" == "pull_request" ]] && echo 1 || echo 5)
+          LOG_LEVEL=FATAL go test -run='$^' -count=$COUNT -bench=. -benchmem ./... | tee ${{ runner.temp }}/gotool.txt
 
       # Add GitHub job summary for pull requests.
       - name: Summarize benchmarks results


### PR DESCRIPTION
# Description

Increase count of benchmarks iterations. And bump `chronos` version.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
