### PR TITLE
docs: basic config.yaml sample extended with "storage.data_dir" option

### DIFF
--- a/docs/en/01-quickstart.md
+++ b/docs/en/01-quickstart.md
@@ -22,6 +22,9 @@ Before launch you need to create a config file:
 config.yaml:
 
 ```yaml
+storage:
+  data_dir: /seq-db-data
+
 mapping:
   path: auto
 ```
@@ -33,6 +36,7 @@ docker run --rm \
   -p 9002:9002 \
   -p 9004:9004 \
   -p 9200:9200 \
+  -v "$(pwd)"/seq-db-data:/seq-db-data \
   -v "$(pwd)"/config.yaml:/seq-db/config.yaml \
   -it ghcr.io/ozontech/seq-db:latest --mode single --config=config.yaml
 ```

--- a/docs/ru/01-quickstart.md
+++ b/docs/ru/01-quickstart.md
@@ -22,6 +22,9 @@ seq-db можно быстро запустить в docker-контейнере
 config.yaml:
 
 ```yaml
+storage:
+  data_dir: /seq-db-data
+
 mapping:
   path: auto
 ```
@@ -33,6 +36,7 @@ docker run --rm \
   -p 9002:9002 \
   -p 9004:9004 \
   -p 9200:9200 \
+  -v "$(pwd)"/seq-db-data:/seq-db-data \
   -v "$(pwd)"/config.yaml:/seq-db/config.yaml \
   -it ghcr.io/ozontech/seq-db:latest --mode single --config=config.yaml
 ```


### PR DESCRIPTION
# Description
I tried to run single mode seq-db using the configuration file from the documentation, but I ran into an error: ```config validation failed","error":"field \"storage.data_dir\" is required``` Then I found out that specifying "storage.data_dir" is just as necessary for startup as "mapping.path",  so I decided to add it to complement the example from the documentation.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
