### PR TITLE
fix(fracmanager): broken cache path causing cold start on every run

### DIFF
--- a/fracmanager/loader.go
+++ b/fracmanager/loader.go
@@ -129,7 +129,7 @@ func (l *Loader) discover(ctx context.Context) ([]*frac.Active, []*frac.Sealed, 
 	locals := make([]*frac.Sealed, 0, total)
 	remotes := make([]*frac.Remote, 0, total)
 
-	loadedInfoCache := NewFracInfoCacheFromDisk(l.infoCache.fileName)
+	loadedInfoCache := NewFracInfoCacheFromDisk(l.infoCache.fullPath)
 
 	for i, manifest := range manifests {
 		switch manifest.Stage() {


### PR DESCRIPTION
This PR fixes an incorrect path to the info cache file, which was causing the store to ignore the existing info cache and start from scratch on every launch.

Impact:
Loading 7000 fractions without cache took ~3000ms. With a functioning cache, this is reduced to ~20ms – a 150x improvement.

---
- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;
