### PR TITLE
perf: inline `binary.Varint` by hand

### DIFF
--- a/frac/sealed/seqids/blocks.go
+++ b/frac/sealed/seqids/blocks.go
@@ -80,17 +80,16 @@ func unpackRawIDsVarint(src []byte, dst []uint64) ([]uint64, error) {
 	dst = dst[:0]
 	id := uint64(0)
 	for len(src) != 0 {
-		ux, n := binary.Uvarint(src) // ok to continue in presence of error
+		udelta, n := binary.Uvarint(src)
 		if n <= 0 {
 			return nil, errors.New("varint decoded with error")
 		}
 
-		x := int64(ux >> 1)
-		if ux&1 != 0 {
-			x = ^x
+		delta := int64(udelta >> 1)
+		if udelta&1 != 0 {
+			delta = ^delta
 		}
 
-		delta := x
 		id += uint64(delta)
 		dst = append(dst, id)
 


### PR DESCRIPTION
# Description

I was running our benchmarks suite and I noticed that for full-text-search scenarios we waste a lot of CPU on `binary.Varint` when doing `seq.MID` unpacking in a hot loop (when search request wants data that was not previously cached).

So I decided to inline that function by hand and ran following search scenario:
```bash
k6 run \
	--summary-trend-stats 'avg,min,med,max,p(90),p(95),p(99)' \
	-e BASE_URL="http://localhost:9002" \
	seq-db-fetch-5k-fulltext.js
```

*Each run took around 60s. I've made two runs (for baseline and modified versions, so four in total) and took results from the second run for each version.*

Before:
```text
HTTP
http_req_duration..............: avg=111.93ms min=3.05ms   med=99.8ms   max=324.25ms p(90)=212.2ms  p(95)=229.13ms p(99)=300.88ms
  { expected_response:true }...: avg=111.93ms min=3.05ms   med=99.8ms   max=324.25ms p(90)=212.2ms  p(95)=229.13ms p(99)=300.88ms
http_req_failed................: 0.00%  0 out of 3847
http_reqs......................: 3847   63.808591/s
```


After:
```text
HTTP
http_req_duration..............: avg=99.81ms min=2.76ms   med=94.59ms  max=295.87ms p(90)=166.47ms p(95)=182.62ms p(99)=230.39ms
  { expected_response:true }...: avg=99.81ms min=2.76ms   med=94.59ms  max=295.87ms p(90)=166.47ms p(95)=182.62ms p(99)=230.39ms
http_req_failed................: 0.00%  0 out of 4004
http_reqs......................: 4004   66.543389/s
```

Also I've noticed improvements in CPU usage (the latter two hills are from modified version, 2 CPU vs 2.35 CPU):
<img width="834" height="295" alt="image" src="https://github.com/user-attachments/assets/fb6d038a-c651-4c91-b91c-dd5eb5bca6d3" />

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
