### PR TITLE
fix(async search): return agg interval in req

### DIFF
--- a/proxy/search/async.go
+++ b/proxy/search/async.go
@@ -479,6 +479,7 @@ func buildRequestAggs(in []*storeapi.AggQuery) []AggQuery {
 			GroupBy:   agg.GroupBy,
 			Func:      agg.Func.MustAggFunc(),
 			Quantiles: agg.Quantiles,
+			Interval:  seq.MID(agg.Interval),
 		})
 	}
 	return reqAggs

--- a/proxyapi/grpc_async_search.go
+++ b/proxyapi/grpc_async_search.go
@@ -181,12 +181,17 @@ func (g *grpcV1) DeleteAsyncSearch(
 
 func makeProtoRequestAggregations(sourceAggs []search.AggQuery) []*seqproxyapi.AggQuery {
 	aggs := make([]*seqproxyapi.AggQuery, 0, len(sourceAggs))
-	for _, agg := range sourceAggs {
+	for _, a := range sourceAggs {
 		agg := &seqproxyapi.AggQuery{
-			Field:     agg.Field,
-			GroupBy:   agg.GroupBy,
-			Func:      seqproxyapi.AggFunc(agg.Func),
-			Quantiles: agg.Quantiles,
+			Field:     a.Field,
+			GroupBy:   a.GroupBy,
+			Func:      seqproxyapi.AggFunc(a.Func),
+			Quantiles: a.Quantiles,
+		}
+
+		if a.Interval != 0 {
+			interval := seq.MIDToDuration(a.Interval).String()
+			agg.Interval = &interval
 		}
 
 		// Support legacy format in which field means groupBy.

--- a/storeapi/grpc_async_search.go
+++ b/storeapi/grpc_async_search.go
@@ -149,6 +149,9 @@ func convertAggQueriesToProto(query []processor.AggQuery) []*storeapi.AggQuery {
 		if q.GroupBy != nil {
 			pq.GroupBy = q.GroupBy.Field
 		}
+		if q.Interval != 0 {
+			pq.Interval = q.Interval
+		}
 		res = append(res, pq)
 	}
 	return res


### PR DESCRIPTION
# Description

Fixed missed agg interval field in async searches request

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
