### PR TITLE
fix: fix unneeded conversion when reading block_info on loading fraction

### DIFF
--- a/frac/sealed/block_info.go
+++ b/frac/sealed/block_info.go
@@ -6,10 +6,8 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/ozontech/seq-db/config"
 	"github.com/ozontech/seq-db/frac/common"
 	"github.com/ozontech/seq-db/logger"
-	"github.com/ozontech/seq-db/seq"
 )
 
 const seqDBMagic = "SEQM"
@@ -40,11 +38,5 @@ func (b *BlockInfo) Unpack(data []byte) error {
 		return errors.New("stats unmarshaling error")
 	}
 	b.Info.MetaOnDisk = 0 // todo: make this correction on sealing and remove this next time
-
-	if b.Info.BinaryDataVer >= config.BinaryDataV2 {
-		b.Info.From = seq.NanosToMID(uint64(b.Info.From))
-		b.Info.To = seq.NanosToMID(uint64(b.Info.To))
-	}
-
 	return nil
 }


### PR DESCRIPTION
# Description

frac Info always has `from` and `to` in milliseconds. There is a unneeded conversion which can rended data not visible for search in `.frac-cache` file is deleted.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;
