### PR TITLE
ci: add deployment of unstable version

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-name: Continuous Benchmarks
+name: Benchmarks
 
 on:
   push:
@@ -10,10 +10,25 @@ on:
 
 permissions:
   contents: write
-  deployments: write
 
 jobs:
-  ci-benchmarks:
+  ci-continuous-benchmarks:
+    if: ${{ github.ref_name == 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy latest (unstable) version of seq-db
+        run: |
+          curl --insecure -X POST "https://${{ secrets.CONTINUOUS_BENCHMARKS_ENDPOINT }}/seqagent/v1/b/up" \
+            -H "Content-Type: application/json" \
+            -H "X-Seqbench-Secret: ${{ secrets.SEQBENCH_SECRET }}" \
+            -d @- <<EOF
+          {
+            "refname": "${{ github.ref_name }}",
+            "commit_sha": "${{ github.sha }}"
+          }
+          EOF
+
+  ci-micro-benchmarks:
     runs-on: self-hosted
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# Description

Whenever new PR gets merged to `main` branch we deploy unstable (or latest) version of seq-db to our servers with set up benchmarking infrastructure.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
