### PR TITLE
chore: cleanup `Dockerfile`

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -16,11 +16,8 @@ ARG VERSION
 ARG BUILD_TIME
 
 ARG CGO_ENABLED=1
-ARG GOOS=linux
-ARG GOARCH=amd64
 
-RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} \
-    go build -trimpath \
+RUN CGO_ENABLED=${CGO_ENABLED} go build -trimpath \
     -tags 'netgo osusergo' \
     -ldflags "-w -s  \
     -X github.com/ozontech/seq-db/buildinfo.Version=${VERSION}  \


### PR DESCRIPTION
# Description

I've made `CGO_ENABLED` variable overridable.

I've removed following variables: `GOOS`, `GOARCH`, `TARGETARCH`.
They seem useless, since we can build images for different platforms using `--platform` flag ([example](https://github.com/ozontech/seq-db/blob/001283cecce7f0d655978f203da39c2f95702729/.github/workflows/cd.yml#L40)).

Also I've added `GO_VERSION` to Dockerfile. This will alow us to easily change Golang versions for `seqbench`.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
