### PR TITLE
fix(async search): recover frac search

### DIFF
--- a/asyncsearcher/async_searcher.go
+++ b/asyncsearcher/async_searcher.go
@@ -396,7 +396,13 @@ func compressQPR(qpr *seq.QPR, cb func(compressed []byte) error) error {
 	return nil
 }
 
-func (as *AsyncSearcher) processFrac(f frac.Fraction, info asyncSearchInfo) error {
+func (as *AsyncSearcher) processFrac(f frac.Fraction, info asyncSearchInfo) (err error) {
+	defer func() {
+		if panicData := util.RecoverToError(recover(), asyncSearchPanics); panicData != nil {
+			err = fmt.Errorf("async search panic during processFrac: %w", panicData)
+		}
+	}()
+
 	qpr, err := f.Search(info.ctx, info.Request.Params)
 	if err != nil {
 		return err

--- a/asyncsearcher/metrics.go
+++ b/asyncsearcher/metrics.go
@@ -42,4 +42,10 @@ var (
 		Name:      "read_only",
 		Help:      "Indicates if store is in async search read-only mode (can not start a new async search) due to disk usage limits",
 	})
+	asyncSearchPanics = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "seq_db_store",
+		Subsystem: "async_search",
+		Name:      "panics_total",
+		Help:      "Number of panics in async search",
+	})
 )


### PR DESCRIPTION
# Description

Handle panics during frac search in async searches
Add async search panics metric

---

- [ ] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
