### PR TITLE
chore: entry count statistics for cache

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -107,7 +107,10 @@ func (c *Cache[V]) Cleanup() uint64 {
 	defer c.mu.Unlock()
 
 	// collect old data
-	var totalFreed uint64
+	var (
+		bytesFreed   uint64
+		entriesFreed uint64
+	)
 	if len(c.payload) > c.maxPayloadSize {
 		c.maxPayloadSize = len(c.payload)
 	}
@@ -117,13 +120,14 @@ func (c *Cache[V]) Cleanup() uint64 {
 		}
 		delete(c.payload, k)
 		e.deleted = true
-		totalFreed += e.size
+		bytesFreed += e.size
+		entriesFreed++
 	}
 
 	c.recreatePayload()
-	c.metrics.reportReleased(totalFreed)
+	c.metrics.reportReleased(bytesFreed, entriesFreed)
 
-	return totalFreed
+	return bytesFreed
 }
 
 func (c *Cache[V]) Evict(key uint32) {
@@ -294,13 +298,14 @@ func (c *Cache[V]) Release() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	entriesFreed := uint64(len(c.payload))
 	var totalFreed uint64
 	for _, e := range c.payload {
 		totalFreed += e.size
 		e.gen.size.Sub(e.size)
 	}
 
-	c.metrics.reportReleased(totalFreed)
+	c.metrics.reportReleased(totalFreed, entriesFreed)
 
 	c.payload = nil
 	c.released = true

--- a/cache/metrics.go
+++ b/cache/metrics.go
@@ -14,7 +14,6 @@ type Metrics struct {
 	SizeRead        prometheus.Counter
 	SizeOccupied    prometheus.Counter
 	SizeReleased    prometheus.Counter
-	EntriesOccupied prometheus.Counter
 	EntriesReleased prometheus.Counter
 	MapsRecreated   prometheus.Counter
 	MissLatency     prometheus.Counter
@@ -56,7 +55,6 @@ func (m *Metrics) reportMiss(size uint64, latencySec float64) {
 		m.MissTotal.Inc()
 		m.SizeOccupied.Add(float64(size))
 		m.MissLatency.Add(latencySec)
-		m.EntriesOccupied.Inc()
 	}
 }
 

--- a/cache/metrics.go
+++ b/cache/metrics.go
@@ -58,7 +58,7 @@ func (m *Metrics) reportMiss(size uint64, latencySec float64) {
 	}
 }
 
-func (m *Metrics) reportReleased(freedBytes uint64, freedEntries uint64) {
+func (m *Metrics) reportReleased(freedBytes, freedEntries uint64) {
 	if m != nil {
 		m.SizeReleased.Add(float64(freedBytes))
 		m.EntriesReleased.Add(float64(freedEntries))

--- a/cache/metrics.go
+++ b/cache/metrics.go
@@ -14,6 +14,8 @@ type Metrics struct {
 	SizeRead        prometheus.Counter
 	SizeOccupied    prometheus.Counter
 	SizeReleased    prometheus.Counter
+	EntriesOccupied prometheus.Counter
+	EntriesReleased prometheus.Counter
 	MapsRecreated   prometheus.Counter
 	MissLatency     prometheus.Counter
 }
@@ -54,12 +56,14 @@ func (m *Metrics) reportMiss(size uint64, latencySec float64) {
 		m.MissTotal.Inc()
 		m.SizeOccupied.Add(float64(size))
 		m.MissLatency.Add(latencySec)
+		m.EntriesOccupied.Inc()
 	}
 }
 
-func (m *Metrics) reportReleased(freed uint64) {
+func (m *Metrics) reportReleased(freedBytes uint64, freedEntries uint64) {
 	if m != nil {
-		m.SizeReleased.Add(float64(freed))
+		m.SizeReleased.Add(float64(freedBytes))
+		m.EntriesReleased.Add(float64(freedEntries))
 	}
 }
 

--- a/docs/en/internal/cache.md
+++ b/docs/en/internal/cache.md
@@ -186,12 +186,14 @@ Each metric is collected separately for each layer.
 - ReattemptsTotal - number of times access method had to reattempt due to entry
   invalidation
 - SizeOccupied - counter of size of the values added to cache on miss
+- EntriesOccupied - counter of entries added to cache on miss
 - SizeRead - counter of size of the values retrieved on hit
--	SizeReleased - counter of size of data we released
+- SizeReleased - counter of size of data we released
+- EntriesReleased - counter of entries removed from cache
 - MapsRecreated - counter of events we recreate cache maps
 
 As a rule, `TouchTotal = HitsTotal + MissTotal + PanicsTotal`.
-Also `TotalSize = SizeOccupied - SizeReleased`.
+Also `TotalSize = SizeOccupied - SizeReleased` and `TotalEntries = EntriesOccupied - EntriesReleased`.
 MissTotal and SizeOccupied are the metrics to optimize cache.
 HitsTotal and SizeRead are the metrics to optimize cache use.
 Rising WaitTotal means concurrent access to the same not-yet-cached value.

--- a/docs/en/internal/cache.md
+++ b/docs/en/internal/cache.md
@@ -186,14 +186,13 @@ Each metric is collected separately for each layer.
 - ReattemptsTotal - number of times access method had to reattempt due to entry
   invalidation
 - SizeOccupied - counter of size of the values added to cache on miss
-- EntriesOccupied - counter of entries added to cache on miss
 - SizeRead - counter of size of the values retrieved on hit
 - SizeReleased - counter of size of data we released
 - EntriesReleased - counter of entries removed from cache
 - MapsRecreated - counter of events we recreate cache maps
 
 As a rule, `TouchTotal = HitsTotal + MissTotal + PanicsTotal`.
-Also `TotalSize = SizeOccupied - SizeReleased` and `TotalEntries = EntriesOccupied - EntriesReleased`.
+Also `TotalSize = SizeOccupied - SizeReleased` and `TotalEntries = MissTotal - EntriesReleased`.
 MissTotal and SizeOccupied are the metrics to optimize cache.
 HitsTotal and SizeRead are the metrics to optimize cache use.
 Rising WaitTotal means concurrent access to the same not-yet-cached value.

--- a/docs/ru/internal/cache.md
+++ b/docs/ru/internal/cache.md
@@ -186,12 +186,14 @@ Each metric is collected separately for each layer.
 - ReattemptsTotal - number of times access method had to reattempt due to entry
   invalidation
 - SizeOccupied - counter of size of the values added to cache on miss
+- EntriesOccupied - counter of entries added to cache on miss
 - SizeRead - counter of size of the values retrieved on hit
--	SizeReleased - counter of size of data we released
+- SizeReleased - counter of size of data we released
+- EntriesReleased - counter of entries removed from cache
 - MapsRecreated - counter of events we recreate cache maps
 
 As a rule, `TouchTotal = HitsTotal + MissTotal + PanicsTotal`.
-Also `TotalSize = SizeOccupied - SizeReleased`.
+Also `TotalSize = SizeOccupied - SizeReleased` and `TotalEntries = EntriesOccupied - EntriesReleased`.
 MissTotal and SizeOccupied are the metrics to optimize cache.
 HitsTotal and SizeRead are the metrics to optimize cache use.
 Rising WaitTotal means concurrent access to the same not-yet-cached value.

--- a/docs/ru/internal/cache.md
+++ b/docs/ru/internal/cache.md
@@ -186,14 +186,13 @@ Each metric is collected separately for each layer.
 - ReattemptsTotal - number of times access method had to reattempt due to entry
   invalidation
 - SizeOccupied - counter of size of the values added to cache on miss
-- EntriesOccupied - counter of entries added to cache on miss
 - SizeRead - counter of size of the values retrieved on hit
 - SizeReleased - counter of size of data we released
 - EntriesReleased - counter of entries removed from cache
 - MapsRecreated - counter of events we recreate cache maps
 
 As a rule, `TouchTotal = HitsTotal + MissTotal + PanicsTotal`.
-Also `TotalSize = SizeOccupied - SizeReleased` and `TotalEntries = EntriesOccupied - EntriesReleased`.
+Also `TotalSize = SizeOccupied - SizeReleased` and `TotalEntries = MissTotal - EntriesReleased`.
 MissTotal and SizeOccupied are the metrics to optimize cache.
 HitsTotal and SizeRead are the metrics to optimize cache use.
 Rising WaitTotal means concurrent access to the same not-yet-cached value.

--- a/fracmanager/cache_maintainer_metrics.go
+++ b/fracmanager/cache_maintainer_metrics.go
@@ -16,6 +16,8 @@ type CacheMaintainerMetrics struct {
 	SizeRead        *prometheus.CounterVec
 	SizeOccupied    *prometheus.CounterVec
 	SizeReleased    *prometheus.CounterVec
+	EntriesOccupied *prometheus.CounterVec
+	EntriesReleased *prometheus.CounterVec
 	MapsRecreated   *prometheus.CounterVec
 	MissLatency     *prometheus.CounterVec
 
@@ -37,6 +39,8 @@ func newDefaultCacheMetrics() *CacheMaintainerMetrics {
 		SizeRead:        cacheSizeRead,
 		SizeOccupied:    cacheSizeOccupied,
 		SizeReleased:    cacheSizeReleased,
+		EntriesOccupied: cacheEntriesOccupied,
+		EntriesReleased: cacheEntriesReleased,
 		MapsRecreated:   cacheMapsRecreated,
 		MissLatency:     cacheMissLatencySec,
 
@@ -59,6 +63,8 @@ func (m *CacheMaintainerMetrics) GetLayerMetrics(layerName string) *cache.Metric
 		SizeRead:        m.SizeRead.WithLabelValues(layerName),
 		SizeOccupied:    m.SizeOccupied.WithLabelValues(layerName),
 		SizeReleased:    m.SizeReleased.WithLabelValues(layerName),
+		EntriesOccupied: m.EntriesOccupied.WithLabelValues(layerName),
+		EntriesReleased: m.EntriesReleased.WithLabelValues(layerName),
 		MapsRecreated:   m.MapsRecreated.WithLabelValues(layerName),
 		MissLatency:     m.MissLatency.WithLabelValues(layerName),
 	}

--- a/fracmanager/cache_maintainer_metrics.go
+++ b/fracmanager/cache_maintainer_metrics.go
@@ -16,7 +16,6 @@ type CacheMaintainerMetrics struct {
 	SizeRead        *prometheus.CounterVec
 	SizeOccupied    *prometheus.CounterVec
 	SizeReleased    *prometheus.CounterVec
-	EntriesOccupied *prometheus.CounterVec
 	EntriesReleased *prometheus.CounterVec
 	MapsRecreated   *prometheus.CounterVec
 	MissLatency     *prometheus.CounterVec
@@ -39,7 +38,6 @@ func newDefaultCacheMetrics() *CacheMaintainerMetrics {
 		SizeRead:        cacheSizeRead,
 		SizeOccupied:    cacheSizeOccupied,
 		SizeReleased:    cacheSizeReleased,
-		EntriesOccupied: cacheEntriesOccupied,
 		EntriesReleased: cacheEntriesReleased,
 		MapsRecreated:   cacheMapsRecreated,
 		MissLatency:     cacheMissLatencySec,
@@ -63,7 +61,6 @@ func (m *CacheMaintainerMetrics) GetLayerMetrics(layerName string) *cache.Metric
 		SizeRead:        m.SizeRead.WithLabelValues(layerName),
 		SizeOccupied:    m.SizeOccupied.WithLabelValues(layerName),
 		SizeReleased:    m.SizeReleased.WithLabelValues(layerName),
-		EntriesOccupied: m.EntriesOccupied.WithLabelValues(layerName),
 		EntriesReleased: m.EntriesReleased.WithLabelValues(layerName),
 		MapsRecreated:   m.MapsRecreated.WithLabelValues(layerName),
 		MissLatency:     m.MissLatency.WithLabelValues(layerName),

--- a/fracmanager/metrics.go
+++ b/fracmanager/metrics.go
@@ -45,6 +45,12 @@ var (
 		Name:      "size_released_bytes_total",
 		Help:      "Size in bytes released from cache",
 	}, []string{"layer"})
+	cacheEntriesReleased = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "seq_db_store",
+		Subsystem: "cache",
+		Name:      "entries_released_total",
+		Help:      "Number of cache entries released by layer",
+	}, []string{"layer"})
 	cacheHitsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "seq_db_store",
 		Subsystem: "cache",
@@ -92,6 +98,12 @@ var (
 		Subsystem: "cache",
 		Name:      "miss_size_bytes_total",
 		Help:      "Total size occupied in cache by layer in bytes",
+	}, []string{"layer"})
+	cacheEntriesOccupied = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "seq_db_store",
+		Subsystem: "cache",
+		Name:      "miss_entries_total",
+		Help:      "Number of cache entries occupied by layer on miss",
 	}, []string{"layer"})
 	cacheMapsRecreated = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "seq_db_store",

--- a/fracmanager/metrics.go
+++ b/fracmanager/metrics.go
@@ -99,12 +99,6 @@ var (
 		Name:      "miss_size_bytes_total",
 		Help:      "Total size occupied in cache by layer in bytes",
 	}, []string{"layer"})
-	cacheEntriesOccupied = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "seq_db_store",
-		Subsystem: "cache",
-		Name:      "miss_entries_total",
-		Help:      "Number of cache entries occupied by layer on miss",
-	}, []string{"layer"})
 	cacheMapsRecreated = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "seq_db_store",
 		Subsystem: "cache",


### PR DESCRIPTION
# Description

allow to see how many blocks are in the cache right now on dashboards

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;
