### PR TITLE
fix: add overlap check for TID block in pattern search

### DIFF
--- a/frac/sealed/token/provider.go
+++ b/frac/sealed/token/provider.go
@@ -75,6 +75,10 @@ func (tp *Provider) findInBlocks(firstTID, lastTID uint32, search func(*Block, i
 	var tids []uint32
 
 	for _, entry := range tp.entries {
+		if !entry.checkTIDsInBlock(firstTID, lastTID) {
+			continue
+		}
+
 		block := tp.findBlock(entry.BlockIndex)
 		firstIndex, lastIndex := entry.narrowIndexes(firstTID, lastTID)
 		indexes, err := search(block, firstIndex, lastIndex)

--- a/frac/sealed/token/table_entry.go
+++ b/frac/sealed/token/table_entry.go
@@ -34,6 +34,18 @@ func (t *TableEntry) narrowIndexes(firstTID, lastTID uint32) (int, int) {
 	return firstIndex, lastIndex
 }
 
+func (t *TableEntry) checkTIDsInBlock(firstTID, lastTID uint32) bool {
+	if lastTID < t.StartTID {
+		return false
+	}
+
+	if firstTID > t.getLastTID() {
+		return false
+	}
+
+	return true
+}
+
 func (t *TableEntry) checkTIDInBlock(tid uint32) bool {
 	if tid < t.StartTID {
 		return false


### PR DESCRIPTION
# Description

`narrowIndexes` is called for for TID entries which do not overlap with provided TID range

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;
