### PR TITLE
fix: add search params validation that from <= to

### DIFF
--- a/proxyapi/grpc_v1.go
+++ b/proxyapi/grpc_v1.go
@@ -201,6 +201,9 @@ func (g *grpcV1) doSearch(
 
 	fromTime := req.Query.From.AsTime()
 	toTime := req.Query.To.AsTime()
+	if fromTime.After(toTime) {
+		return nil, status.Error(codes.InvalidArgument, `"from" timestamp must not be after "to" timestamp`)
+	}
 	if span.IsRecordingEvents() {
 		span.AddAttributes(
 			trace.StringAttribute("query", req.Query.Query),


### PR DESCRIPTION
# Description

otherwise we can get a panic on histogram query (negative array size)

```
{"level":"error","ts":"2026-06-16T08:39:38.829Z","message":"runtime error: makeslice: len out of range"}
goroutine 99941390 [running]:
runtime/debug.Stack()
    runtime/debug/stack.go:26 +0x5e
runtime/debug.PrintStack()
    runtime/debug/stack.go:18 +0x13
github.com/ozontech/seq-db/util.Recover({0x17fc448?, 0xc000374d20?}, {0x17e4380, 0x17dee00})
    github.com/ozontech/seq-db/util/err.go:27 +0x65
github.com/ozontech/seq-db/util.RecoverToError({0x13e1d40?, 0x17dee00?}, {0x17fc448, 0xc000374d20})
    github.com/ozontech/seq-db/util/err.go:33 +0x4f
github.com/ozontech/seq-db/fracmanager.(*Searcher).fracSearch.func1()
    github.com/ozontech/seq-db/fracmanager/searcher.go:248 +0x4d
panic({0x13e1d40?, 0x17dee00?})
    runtime/panic.go:783 +0x132
github.com/ozontech/seq-db/frac/processor.iterateEvalTree({0x17f7998, 0xc3f7801220}, {0xc6863eaa20, {0x2165a20, 0x0, 0x0}, 0x1, 0x18b983022ecb7200, 0x18b9830081e13300, {0x0, ...}, ...}, ...)
    github.com/ozontech/seq-db/frac/processor/search.go:189 +0x14a
github.com/ozontech/seq-db/frac/processor.IndexSearch({0x17f7998, 0xc3f7801220}, {0xc6863eaa20, {0x2165a20, 0x0, 0x0}, 0x1, 0x18b983022ecb7200, 0x18b9830081e13300, {0x0, ...}, ...}, ...)
    github.com/ozontech/seq-db/frac/processor/search.go:111 +0x6df
github.com/ozontech/seq-db/frac.(*sealedDataProvider).Search(0xcbb46b70e0, {0xc6863eaa20, {0x2165a20, 0x0, 0x0}, 0x1, 0x18b983022ecb7200, 0x18b9830081e13300, {0x0, 0x0}, ...})
    github.com/ozontech/seq-db/frac/sealed_index.go:125 +0x392
github.com/ozontech/seq-db/frac.(*Sealed).Search(0xd34b2a5360?, {0x17f7998?, 0xc3f7801220?}, {0xc6863eaa20, {0x2165a20, 0x0, 0x0}, 0x1, 0x18b983022ecb7200, 0x18b9830081e13300, ...})
    github.com/ozontech/seq-db/frac/sealed.go:483 +0xb8
github.com/ozontech/seq-db/fracmanager.(*fractionProxy).Search(0x3?, {0x17f7998?, 0xc3f7801220?}, {0xc6863eaa20, {0x2165a20, 0x0, 0x0}, 0x1, 0x18b983022ecb7200, 0x18b9830081e13300, ...})
    github.com/ozontech/seq-db/fracmanager/proxy_frac.go:70 +0x115
github.com/ozontech/seq-db/fracmanager.(*Searcher).fracSearch(0xdc97277f5e?, {0x17f7998?, 0xc3f7801220?}, {0xc6863eaa20, {0x2165a20, 0x0, 0x0}, 0x1, 0x18b983022ecb7200, 0x18b9830081e13300, ...}, ...)
    github.com/ozontech/seq-db/fracmanager/searcher.go:252 +0xd6
github.com/ozontech/seq-db/fracmanager.(*Searcher).searchDocsAsync.func2()
    github.com/ozontech/seq-db/fracmanager/searcher.go:210 +0x17c
created by github.com/ozontech/seq-db/fracmanager.(*Searcher).searchDocsAsync in goroutine 99941381
    github.com/ozontech/seq-db/fracmanager/searcher.go:207 +0x295
```

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
