### PR TITLE
fix: bring back default capacity for LID block

### DIFF
--- a/indexwriter/lid_accumulator.go
+++ b/indexwriter/lid_accumulator.go
@@ -1,6 +1,9 @@
 package indexwriter
 
-import "github.com/ozontech/seq-db/frac/sealed/lids"
+import (
+	"github.com/ozontech/seq-db/consts"
+	"github.com/ozontech/seq-db/frac/sealed/lids"
+)
 
 type lidAccumulator struct {
 	blockCapacity int
@@ -17,6 +20,10 @@ func newLIDAccumulator(
 	blockCapacity int,
 	onBlock func(unpackedLIDBlock) error,
 ) *lidAccumulator {
+	if blockCapacity == 0 {
+		blockCapacity = consts.DefaultLIDBlockCap
+	}
+
 	a := &lidAccumulator{
 		blockCapacity: blockCapacity,
 		onBlock:       onBlock,


### PR DESCRIPTION
# Description

I've accidentally lost this check in #401 :)

I've noticed increased memory allocation in microbenchmarks (sealing) and decided to get to the root cause.

<img width="1578" height="790" alt="image" src="https://github.com/user-attachments/assets/de23cb68-dc24-4441-b1ed-abdb2bdcdf0c" />


---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
