### PR TITLE
fix: correctly release buckets

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -303,6 +303,7 @@ func (c *Cache[V]) Release() {
 	for _, e := range c.payload {
 		totalFreed += e.size
 		e.gen.size.Sub(e.size)
+		e.deleted = true
 	}
 
 	c.metrics.reportReleased(totalFreed, entriesFreed)

--- a/cache/cleaner.go
+++ b/cache/cleaner.go
@@ -28,14 +28,15 @@ type CleanStat struct {
 	BucketsCleaned int
 }
 type Cleaner struct {
-	sizeLimit uint64
-	metrics   *CleanerMetrics
+	sizeLimit  uint64
+	maxGenSize uint64
+	metrics    *CleanerMetrics
 
-	mu          sync.Mutex
-	buckets     []bucket
 	generations []*Generation
-	lastGen     *Generation
-	maxGenSize  uint64
+
+	mu      sync.Mutex
+	buckets []bucket
+	lastGen *Generation
 }
 
 func NewCleaner(sizeLimit uint64, metrics *CleanerMetrics) *Cleaner {
@@ -163,35 +164,24 @@ func (c *Cleaner) CleanEmptyGenerations() int {
 }
 
 func (c *Cleaner) ReleaseBuckets() int {
-	toDelete := []int{}
-
-	// collect released
-	for i, b := range c.getBuckets() {
-		if b.Released() {
-			toDelete = append(toDelete, i)
-		}
-	}
-
-	if len(toDelete) == 0 {
-		return 0
-	}
-
-	// remove released
 	c.mu.Lock()
-	last := len(c.buckets)
-	for _, i := range toDelete {
-		last--
-		if i >= last {
-			break
+
+	var l int
+	for _, b := range c.buckets {
+		if !b.Released() {
+			c.buckets[l] = b
+			l++
 		}
-		c.buckets[i] = c.buckets[last]
 	}
-	c.buckets = c.buckets[:last]
+
+	released := len(c.buckets) - l
+
+	clear(c.buckets[l:])
+	c.buckets = c.buckets[:l]
+
 	c.mu.Unlock()
 
-	released := len(toDelete)
 	c.metrics.BucketsSub(released)
-
 	return released
 }
 


### PR DESCRIPTION
# Description

One of the nastiest I've ever seen which leads to incorrect accounting of cache-owned memory.

With compaction enabled previous code could overwrite live buckets with other released (or live) buckets leading to x2 cache memory usage.

An example when we lose live buckets:
```
buckets = [A, B, C, D, E]; toDelete=[A, E]
```

After the `ReleaseBuckets()` we end up with `buckets = [E, B, C]` losing bucket `D`. This bucket will be eventually released because fraction (bucket's owner) is alive and will suicide (therefore calling `Release()`) but memory accounting will be broken.

Memory accounting will be broken because the generation bucket belongs to will be evicted therefore memory usage of this bucket will not be accounted.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
