### PR TITLE
fix: correctly handle non-existing ids

### DIFF
--- a/frac/fraction_test.go
+++ b/frac/fraction_test.go
@@ -787,6 +787,35 @@ func (s *FractionTestSuite) TestBasicAggregation() {
 		})
 }
 
+func (s *FractionTestSuite) TestCornersID() {
+	mid := seq.MID(946731600000000000)
+
+	s.insertDocuments([]string{
+		`{"timestamp":"2000-01-01T13:00:00.000Z","service":"sum1","v":1}`,
+	})
+
+	s.Require().Equal(mid, s.fraction.Info().From)
+	s.Require().Equal(mid, s.fraction.Info().To)
+
+	data, err := s.fraction.Fetch(s.T().Context(), []seq.ID{{
+		MID: seq.MID(mid),
+		RID: 0,
+	}}, false)
+
+	s.Require().NoError(err)
+	// [Fetch] returns `nil` for every non-found id.
+	s.Require().Equal([][]byte{nil}, data)
+
+	data, err = s.fraction.Fetch(s.T().Context(), []seq.ID{{
+		MID: seq.MID(mid),
+		RID: seq.SystemRID,
+	}}, false)
+
+	s.Require().NoError(err)
+	// [Fetch] returns `nil` for every non-found id.
+	s.Require().Equal([][]byte{nil}, data)
+}
+
 func (s *FractionTestSuite) TestAggSum() {
 	docs := []string{
 		`{"timestamp":"2000-01-01T13:00:00.000Z","service":"sum1","v":1}`,

--- a/frac/sealed_index.go
+++ b/frac/sealed_index.go
@@ -357,7 +357,9 @@ func (fi *sealedFetchIndex) findLIDs(ids []seq.ID) []seq.LID {
 			return fi.idsIndex.LessOrEqual(seq.LID(lid), id)
 		}))
 
-		if id.MID == fi.idsIndex.GetMID(lid) && id.RID == fi.idsIndex.GetRID(lid) {
+		// In case when ID does not exist in fraction, binary search will return `right + 1`.
+		// Such value will correspond to the amount of LIDs in fraction, not to the index.
+		if lid <= seq.LID(right) && id.MID == fi.idsIndex.GetMID(lid) && id.RID == fi.idsIndex.GetRID(lid) {
 			res[i] = lid
 		}
 


### PR DESCRIPTION
# Description

Rarely we encountered panics (out of bounds access) and I decided to shove the stacktrace into Fable and observe how it will handle the bug. Well, it found the root-cause.

```
{"level":"error","ts":"2026-07-07T14:13:34.054Z","message":"runtime error: index out of range [1508] with length 1508"}
goroutine 13507559 [running]:
runtime/debug.Stack()
    runtime/debug/stack.go:26 +0x5e
runtime/debug.PrintStack()
    runtime/debug/stack.go:18 +0x13
github.com/ozontech/seq-db/util.Recover({0x192a3a0?, 0xc00063af00?}, {0x729e409aa098, 0xc1e0afbae8})
    github.com/ozontech/seq-db/util/err.go:27 +0x65
github.com/ozontech/seq-db/util.RecoverToError({0x1634bc0?, 0xc1e0afbae8?}, {0x192a3a0, 0xc00063af00})
    github.com/ozontech/seq-db/util/err.go:33 +0x4f
github.com/ozontech/seq-db/fracmanager.fracFetch.func1()
    github.com/ozontech/seq-db/fracmanager/fetcher.go:110 +0x4d
panic({0x1634bc0?, 0xc1e0afbae8?})
    runtime/panic.go:783 +0x132
github.com/ozontech/seq-db/frac/sealed/seqids.(*unpackCache).GetValByLID(...)
    github.com/ozontech/seq-db/frac/sealed/seqids/unpack_cache.go:47
github.com/ozontech/seq-db/frac/sealed/seqids.(*Provider).MID(0xc100e98550, 0xf15e4)
    github.com/ozontech/seq-db/frac/sealed/seqids/provider.go:54 +0x71
github.com/ozontech/seq-db/frac.(*sealedIDsIndex).GetMID(0xc0f764d0a0, 0xf15e4)
    github.com/ozontech/seq-db/frac/sealed_index.go:148 +0x35
github.com/ozontech/seq-db/frac.(*sealedFetchIndex).findLIDs(0xc100e985f0, {0xc1dad45630, 0x1, 0xc016b9d500?})
    github.com/ozontech/seq-db/frac/sealed_index.go:360 +0x13b
github.com/ozontech/seq-db/frac.(*sealedFetchIndex).GetDocPos(0xc100e985f0, {0xc1dad45630?, 0xc?, 0x1?}, 0x0)
    github.com/ozontech/seq-db/frac/sealed_index.go:302 +0x26
github.com/ozontech/seq-db/frac/processor.IndexFetch({0xc1dad45630, 0x1, 0x1}, 0x0, 0xc0f764d080, {0x19242a0, 0xc100e985f0}, {0xc58016d668, 0x1, 0x1})
    github.com/ozontech/seq-db/frac/processor/fetch.go:16 +0xa6
github.com/ozontech/seq-db/frac.(*sealedDataProvider).Fetch(0xc486c761b0, {0xc1dad45630, 0x1, 0x1}, 0x0)
    github.com/ozontech/seq-db/frac/sealed_index.go:105 +0x2b2
github.com/ozontech/seq-db/frac.(*Sealed).Fetch(0x108e57c?, {0x1925690?, 0xc0b6564230?}, {0xc1dad45630, 0x1, 0x1}, 0x0)
    github.com/ozontech/seq-db/frac/sealed.go:477 +0xad
github.com/ozontech/seq-db/fracmanager.fracFetch({0x1925690?, 0xc0b6564230?}, {0x192a088?, 0xc3533a2c30?}, {0xc1dad45630?, 0xc140d549a0?, 0x3e8?}, 0x70?)
    github.com/ozontech/seq-db/fracmanager/fetcher.go:114 +0xb6
github.com/ozontech/seq-db/fracmanager.(*Fetcher).fetchDocsAsync.func2()
    github.com/ozontech/seq-db/fracmanager/fetcher.go:87 +0xb8
created by github.com/ozontech/seq-db/fracmanager.(*Fetcher).fetchDocsAsync in goroutine 13507558
    github.com/ozontech/seq-db/fracmanager/fetcher.go:85 +0x1da
{"level":"error","ts":"2026-07-07T14:13:34.055Z","message":"fetch error","error":"internal error: fetch panicked on fraction seq-db-01KWYD9DBNAYK3Y859ZGRCC8A4, error=runtime error: index out of range [1508] with length 1508"}
```

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [x] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: Fable 5
Prompt: Asked to debug the panic
```
