### PR TITLE
fix:  data loss in asyncsearch merge caused by concurrent retention deletion of fracs

### DIFF
--- a/asyncsearcher/async_searcher.go
+++ b/asyncsearcher/async_searcher.go
@@ -683,9 +683,10 @@ func (as *AsyncSearcher) FetchSearchResult(r FetchSearchResultRequest) (FetchSea
 
 	var qpr seq.QPR
 	var fracsDone, fracsInQueue int
+	histInterval := seq.MillisToMID(info.Request.Params.HistInterval)
 	if info.merged.Load() {
 		p := path.Join(as.config.DataDir, r.ID+asyncSearchExtMergedQPR)
-		qpr, _ = as.loadSearchResult([]string{p}, r.Limit, r.Order)
+		qpr, _ = as.loadSearchResult([]string{p}, r.Limit, r.Order, histInterval)
 		fracsDone = len(info.Fractions)
 		fracsInQueue = 0
 	} else {
@@ -693,7 +694,7 @@ func (as *AsyncSearcher) FetchSearchResult(r FetchSearchResultRequest) (FetchSea
 		if err != nil {
 			logger.Fatal("can't load async search result", zap.String("id", r.ID), zap.Error(err))
 		}
-		qpr, _ = as.loadSearchResult(p, r.Limit, r.Order)
+		qpr, _ = as.loadSearchResult(p, r.Limit, r.Order, histInterval)
 		fracsDone = len(p)
 		fracsInQueue = len(info.Fractions) - fracsDone
 	}
@@ -725,16 +726,21 @@ func (as *AsyncSearcher) FetchSearchResult(r FetchSearchResultRequest) (FetchSea
 	}, true
 }
 
-func (as *AsyncSearcher) loadSearchResult(qprsPaths []string, limit int, order seq.DocsOrder) (seq.QPR, int) {
+func (as *AsyncSearcher) loadSearchResult(qprsPaths []string, limit int, order seq.DocsOrder, histInterval seq.MID) (seq.QPR, int) {
 	qpr := seq.QPR{}
 	size := 0
 	for _, qprPath := range qprsPaths {
 		compressedQPR, err := os.ReadFile(qprPath)
-		size += len(compressedQPR)
 		if err != nil {
+			if os.IsNotExist(err) {
+				// the corresponding fraction may have been removed concurrently by retention,
+				// so the qpr file may not exist
+				continue
+			}
 			logger.Error("can't read async search result from file", zap.String("path", qprPath), zap.Error(err))
 			return seq.QPR{}, 0
 		}
+		size += len(compressedQPR)
 		qprRaw, err := zstd.Decompress(compressedQPR, nil)
 		if err != nil {
 			logger.Fatal("can't decompress async search result", zap.String("path", qprPath), zap.Error(err))
@@ -748,7 +754,7 @@ func (as *AsyncSearcher) loadSearchResult(qprsPaths []string, limit int, order s
 		if len(tail) > 0 {
 			logger.Fatal("unexpected tail when unmarshaling binary QPR", zap.String("path", qprPath))
 		}
-		seq.MergeQPRs(&qpr, []*seq.QPR{&tmp}, limit, 1, order)
+		seq.MergeQPRs(&qpr, []*seq.QPR{&tmp}, limit, histInterval, order)
 	}
 	return qpr, size
 }
@@ -785,9 +791,8 @@ func (as *AsyncSearcher) merge() {
 			continue
 		}
 		mergeJobs = append(mergeJobs, mergeJob{
-			ID:    id,
-			Fracs: info.Fractions,
-			Info:  info,
+			ID:   id,
+			Info: info,
 		})
 	}
 	as.requestsMu.RUnlock()
@@ -799,8 +804,7 @@ func (as *AsyncSearcher) merge() {
 }
 
 type mergeJob struct {
-	ID    string
-	Fracs []fracSearchState
+	ID string
 
 	Info asyncSearchInfo
 }
@@ -808,12 +812,13 @@ type mergeJob struct {
 func (as *AsyncSearcher) mergeQPRs(job mergeJob) {
 	start := time.Now()
 	var qprs []string
-	for _, f := range job.Fracs {
+	for _, f := range job.Info.Fractions {
 		qprFilename := getQPRFilename(job.ID, f.Name)
 		qprPath := path.Join(as.config.DataDir, qprFilename)
 		qprs = append(qprs, qprPath)
 	}
-	qpr, sizeBefore := as.loadSearchResult(qprs, job.Info.Request.Params.Limit, seq.DocsOrderDesc)
+	params := job.Info.Request.Params
+	qpr, sizeBefore := as.loadSearchResult(qprs, params.Limit, params.Order, seq.MillisToMID(params.HistInterval))
 
 	var sizeAfter int
 	storeMQPR := func(compressed []byte) error {
@@ -839,7 +844,7 @@ func (as *AsyncSearcher) mergeQPRs(job mergeJob) {
 	logger.Info("QPRs have been merged",
 		zap.String("id", job.ID),
 		zap.Float64("ratio", float64(sizeBefore)/float64(sizeAfter)),
-		zap.Int("fracs", len(job.Fracs)),
+		zap.Int("fracs", len(qprs)),
 		zap.Duration("took", time.Since(start)),
 	)
 }

--- a/asyncsearcher/async_searcher_test.go
+++ b/asyncsearcher/async_searcher_test.go
@@ -78,3 +78,66 @@ func TestAsyncSearcherMaintain(t *testing.T) {
 
 	as.processWg.Wait()
 }
+
+// partialProvider lists both fractions (so info.Fractions gets two entries),
+// but only "present" is acquirable. "missing" simulates a fraction that was
+// removed by the time the search reached it: it stays listed in info.Fractions
+// yet never produces a .qpr file.
+type partialProvider struct {
+	list fracmanager.List
+}
+
+func (p *partialProvider) AcquireFractions() (fracmanager.List, func()) {
+	return p.list, func() {}
+}
+
+func (p *partialProvider) AcquireFraction(name string) (frac.Fraction, func(), bool) {
+	for _, f := range p.list {
+		if f.Info().Name() == name && name == "present" {
+			return f, func() {}, true
+		}
+	}
+	return nil, func() {}, false
+}
+
+// TestMergeSkipsMissingFrac is a regression test: when a fraction listed in
+// info.Fractions was skipped (already removed) and produced no .qpr, merge used
+// to build its path from info.Fractions, hit a missing file in loadSearchResult,
+// discard the whole accumulated result, write an empty .mqpr and delete the
+// real .qpr — losing the only matching document.
+func TestMergeSkipsMissingFrac(t *testing.T) {
+	r := require.New(t)
+
+	cfg := AsyncSearcherConfig{DataDir: t.TempDir()}
+	mp, err := mappingprovider.New("", mappingprovider.WithMapping(seq.Mapping{}))
+	r.NoError(err)
+
+	as := MustStartAsync(cfg, mp, nil)
+	t.Cleanup(func() { as.readOnly.Store(false) })
+
+	presentFrac := &fakeFrac{
+		info: common.Info{Path: "present"},
+		dp:   fakeDP{qpr: seq.QPR{IDs: []seq.IDSource{{ID: seq.ID{MID: 42}}}, Total: 1}},
+	}
+	missingFrac := &fakeFrac{info: common.Info{Path: "missing"}}
+	provider := &partialProvider{list: fracmanager.List{presentFrac, missingFrac}}
+
+	req := AsyncSearchRequest{
+		ID:        uuid.New().String(),
+		Params:    processor.SearchParams{Limit: 1000, Order: seq.DocsOrderDesc},
+		Query:     "*",
+		Retention: time.Hour,
+	}
+	r.NoError(as.StartSearch(req, provider))
+	as.processWg.Wait()
+
+	// "missing" produced no .qpr; "present" did. Merge must not drop the
+	// present result while collapsing the request into a single .mqpr.
+	as.merge()
+
+	resp, ok := as.FetchSearchResult(FetchSearchResultRequest{ID: req.ID, Limit: 1000, Order: seq.DocsOrderDesc})
+	r.True(ok)
+	r.Equal(AsyncSearchStatusDone, resp.Status)
+	r.Len(resp.QPR.IDs, 1)
+	r.Equal(seq.MID(42), resp.QPR.IDs[0].ID.MID)
+}


### PR DESCRIPTION
- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;
