### PR TITLE
fix: prevent unique stack traces explosion in mem profile

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -36,8 +36,10 @@ func treeFold[V any](op func(V, V) V, values []V) V {
 
 	mid := len(values) / 2
 
-	return op(
-		treeFold(op, values[:mid]),
-		treeFold(op, values[mid:]),
-	)
+	// single call site to prevent stack traces explosion of alloc samples on ultra-deep OR trees
+	var children [2]V
+	for i, part := range [2][]V{values[:mid], values[mid:]} {
+		children[i] = treeFold(op, part)
+	}
+	return op(children[0], children[1])
 }


### PR DESCRIPTION
# Description

Currently, fixing it only for tree folding. It's harder to fix `nodeOr` since using a single call site reduces performance of OR queries. However, currently most allocs (LID block reads) happen when deep trees are created (we have eager LID cursors), so I assume the fix makes sense. `nodeOr` will be fixed with unrolled nodes and batched execution (partially).

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;