### PR TITLE
fix: fix file descriptor on corrupted WAL copy

### DIFF
--- a/fracmanager/fracmanager.go
+++ b/fracmanager/fracmanager.go
@@ -225,7 +225,7 @@ func startStatsWorker(ctx context.Context, cfg *Config, reg *fractionRegistry, w
 			stats.SetMetrics() // Update Prometheus metrics
 
 			corruptions := countDocsFiles(filepath.Join(cfg.DataDir, consts.BrokenDir))
-			walCorruptionsTotal.Add(float64(corruptions))
+			walCorruptions.Set(float64(corruptions))
 		})
 		logger.Info("stats loop is stopped")
 	}()

--- a/fracmanager/metrics.go
+++ b/fracmanager/metrics.go
@@ -213,10 +213,10 @@ var (
 		Help:      "Number of bytes read from disk storage",
 	})
 
-	walCorruptionsTotal = promauto.NewGauge(prometheus.GaugeOpts{
+	walCorruptions = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "seq_db_store",
 		Subsystem: "storage",
-		Name:      "wal_corruptions_total",
+		Name:      "wal_corruptions",
 		Help:      "Number of WAL files with detected corruption during replay",
 	})
 )

--- a/util/fs.go
+++ b/util/fs.go
@@ -152,7 +152,7 @@ func CopyFile(src, dst string) error {
 	}
 	defer in.Close()
 
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC, 0o666)
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o666)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

Messed up flags while opening a file to copy a corrupted WAL.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;