### PR TITLE
fix: stop sw on context cancel (search err)

### DIFF
--- a/frac/sealed_index.go
+++ b/frac/sealed_index.go
@@ -124,12 +124,13 @@ func (dp *sealedDataProvider) Search(params processor.SearchParams) (*seq.QPR, e
 	)
 
 	t := sw.Start("total")
+	defer t.Stop()
+
 	qpr, err := processor.IndexSearch(dp.ctx, params, dp.getSearchIndex(), aggLimits, sw)
 	if err != nil {
 		return nil, err
 	}
 	qpr.IDs.ApplyHint(dp.info.Name())
-	t.Stop()
 
 	return qpr, nil
 }


### PR DESCRIPTION
# Description

Spot warning logs while debugging an issue - stopwatch not stopped on search error.

```
{"level":"warn","ts":"2026-07-13T18:22:26.539Z","message":"wrong Stopwatch usage: call getValues() w/o Stop()","name":"total"}
{"level":"warn","ts":"2026-07-13T18:22:26.539Z","message":"wrong Stopwatch usage: call getValues() w/o Stop()","name":"total"}
{"level":"warn","ts":"2026-07-13T18:22:26.539Z","message":"wrong Stopwatch usage: call getValues() w/o Stop()","name":"total"}
{"level":"warn","ts":"2026-07-13T18:22:26.539Z","message":"wrong Stopwatch usage: call getValues() w/o Stop()","name":"total"}
{"level":"warn","ts":"2026-07-13T18:22:26.539Z","message":"wrong Stopwatch usage: call getValues() w/o Stop()","name":"total"}
{"level":"warn","ts":"2026-07-13T18:22:26.539Z","message":"wrong Stopwatch usage: call getValues() w/o Stop()","name":"total"}
{"level":"warn","ts":"2026-07-13T18:22:26.539Z","message":"wrong Stopwatch usage: call getValues() w/o Stop()","name":"total"}
{"level":"warn","ts":"2026-07-13T18:22:26.539Z","message":"wrong Stopwatch usage: call getValues() w/o Stop()","name":"total"}
{"level":"warn","ts":"2026-07-13T18:22:26.539Z","message":"wrong Stopwatch usage: call getValues() w/o Stop()","name":"total"}
{"level":"warn","ts":"2026-07-13T18:22:26.539Z","message":"wrong Stopwatch usage: call getValues() w/o Stop()","name":"total"}
{"level":"warn","ts":"2026-07-13T18:22:26.540Z","message":"wrong Stopwatch usage: call getValues() w/o Stop()","name":"total"}
{"level":"error","ts":"2026-07-13T18:22:26.543Z","message":"search error","error":"search error: context canceled field: exception, query: 2","request":{"query":"...}}
```

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;