### PR TITLE
fix: log search error if error code is present

### DIFF
--- a/storeapi/grpc_search.go
+++ b/storeapi/grpc_search.go
@@ -48,6 +48,11 @@ func (g *GrpcV1) Search(ctx context.Context, req *storeapi.SearchRequest) (*stor
 		span.SetStatus(trace.Status{Code: 1, Message: err.Error()})
 		logger.Error("search error", zap.Error(err), zap.Object("request", (*searchRequestMarshaler)(req)))
 	}
+	if data != nil && data.Code != storeapi.SearchErrorCode_NO_ERROR {
+		logger.Error("search error",
+			zap.Error(fmt.Errorf(storeapi.SearchErrorCode_name[int32(data.Code)])),
+			zap.Object("request", (*searchRequestMarshaler)(req)))
+	}
 
 	tr.Done()
 	if req.Explain && data != nil {

--- a/storeapi/grpc_search.go
+++ b/storeapi/grpc_search.go
@@ -2,6 +2,7 @@ package storeapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -50,7 +51,7 @@ func (g *GrpcV1) Search(ctx context.Context, req *storeapi.SearchRequest) (*stor
 	}
 	if data != nil && data.Code != storeapi.SearchErrorCode_NO_ERROR {
 		logger.Error("search error",
-			zap.Error(fmt.Errorf(storeapi.SearchErrorCode_name[int32(data.Code)])),
+			zap.Error(errors.New(storeapi.SearchErrorCode_name[int32(data.Code)])),
 			zap.Object("request", (*searchRequestMarshaler)(req)))
 	}
 


### PR DESCRIPTION
# Description

Log `search error` if error code is present. Currently we do not log errors like `SearchErrorCode_TOO_MANY_FRACTION_TOKENS` and `SearchErrorCode_MEMORY_LIMIT_EXCEEDED`, but happily log parser errors in this log. 

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;
