### PR TITLE
feat: support wilcard token `*` for complex queries

### DIFF
--- a/frac/fraction_test.go
+++ b/frac/fraction_test.go
@@ -237,6 +237,7 @@ func (s *FractionTestSuite) TestWildcardSymbolsSearch() {
 
 	s.insertDocuments(docs)
 
+	s.AssertSearch("((*) OR message:first) AND message:second", docs, []int{1})
 	s.AssertSearch(`message:*`, docs, []int{3, 2, 1, 0})
 	s.AssertSearch(`message:value`, docs, []int{1, 0})
 	s.AssertSearch(`message:value*`, docs, []int{2, 1, 0})

--- a/parser/seqql.go
+++ b/parser/seqql.go
@@ -388,7 +388,7 @@ func parseSeqQLSubexpr(lex *lexer, mapping seq.Mapping, depth int) (*ASTNode, er
 		return nil, fmt.Errorf("unexpected end of query")
 	}
 
-	if lex.IsKeyword(string(wildcardRune)) && depth == 0 {
+	if lex.IsKeyword(string(wildcardRune)) {
 		lex.Next()
 		// Query is `*`.
 		return &ASTNode{

--- a/parser/seqql_filter_test.go
+++ b/parser/seqql_filter_test.go
@@ -74,6 +74,8 @@ func TestSeqQLAll(t *testing.T) {
 
 	test("", "*")
 	test("*", "*")
+	test("((*))", "*")
+	test("((*) OR service:foo) AND service:bar", "((* or service:foo) and service:bar)")
 
 	// Propagate "not".
 	test(`NOT NOT text:a`, `text:a`)


### PR DESCRIPTION
# Description

For some reason, we allowed users to write queries like `* AND foo:bar`, but queries like `(* AND foo:bar)` were considered to be incorrect. This PR fixes it.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
