### PR TITLE
chore: cache space reservation when sorting is enabled

### DIFF
--- a/fracmanager/config.go
+++ b/fracmanager/config.go
@@ -81,19 +81,26 @@ func FillConfigWithDefault(config *Config) *Config {
 		config.ReplayWorkers = consts.DefaultReplayWorkers
 	}
 
-	if config.SortCacheSize == 0 {
+	// Document sorting is enabled.
+	if !config.Fraction.SkipSortDocs {
 		const (
 			SdocsCacheSizeMultiplier = 8
 			SdocsCacheSizeMaxRatio   = 0.8
 		)
-		config.SortCacheSize = config.FracSize * SdocsCacheSizeMultiplier
+
 		if config.SortCacheSize > config.CacheSize {
-			config.SortCacheSize = uint64(float64(config.CacheSize) * 0.8)
+			logger.Fatal("cache size misconfiguration",
+				zap.Float64("total_cache_size_mb", util.SizeToUnit(config.CacheSize, "mb")),
+				zap.Float64("sort_cache_size_mb", util.SizeToUnit(config.SortCacheSize, "mb")))
 		}
-	} else if config.SortCacheSize > config.CacheSize {
-		logger.Fatal("cache size misconfiguration",
-			zap.Float64("total_cache_size_mb", util.SizeToUnit(config.CacheSize, "mb")),
-			zap.Float64("sort_cache_size_mb", util.SizeToUnit(config.SortCacheSize, "mb")))
+
+		// Set defaults.
+		if config.SortCacheSize == 0 {
+			config.SortCacheSize = config.FracSize * SdocsCacheSizeMultiplier
+			if config.SortCacheSize > config.CacheSize {
+				config.SortCacheSize = uint64(float64(config.CacheSize) * 0.8)
+			}
+		}
 	}
 
 	return config


### PR DESCRIPTION
# Description

Previous version substracted cache size even if we skip documents sorting.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
