### PR TITLE
perf: bulk-copy bitpacked streams instead of element-wise decode

### DIFF
--- a/packer/copy_uints.go
+++ b/packer/copy_uints.go
@@ -1,0 +1,78 @@
+// Byte->word conversion of the little-endian streams.
+//
+// On little-endian hosts the in-memory representation of []uint32/[]uint64 is
+// exactly the on-disk little-endian stream, so the conversion is a bulk copy
+// (runtime.memmove) instead of an element-wise decode loop. The loop tops out
+// at ~4.5 GiB/s regardless of size (instruction-bound); memmove runs at
+// memory/cache bandwidth (30-70 GiB/s), see copy_uints_test.go benchmarks.
+// For the smallest inputs (streams of a couple of words: offsets arrays of
+// blocks dominated by one heavy token, fraction-tail blocks) the memmove call
+// overhead loses to a plain loop, so those stay element-wise.
+//
+// Big-endian hosts use the element-wise fallback in copy_uints_be.go.
+
+//go:build 386 || amd64 || arm || arm64 || loong64 || mipsle || mips64le || ppc64le || riscv64 || wasm
+
+package packer
+
+import (
+	"encoding/binary"
+	"fmt"
+	"unsafe"
+)
+
+// smallCopyWords: at or below this the plain loop beats the memmove call
+// overhead. Measured crossover (BenchmarkSmallCopyCrossover, Cascade Lake):
+// the loop wins at 1-2 words, ~ties at 3, memmove wins from 4 on (-15%)
+// and widens quickly (-48% at 8 words).
+const smallCopyWords = 3
+
+// copyAsUints32 reinterprets dst as bytes and bulk-copies src into it.
+// Panics if len(src) is not a multiple of the word size — same fail-fast
+// behavior on a corrupted stream as the element-wise decode had; callers
+// validate the length beforehand.
+func copyAsUints32(src []byte, dst []uint32) []uint32 {
+	if len(src)%sizeOfUint32 != 0 {
+		panic(fmt.Sprintf("packer: ragged uint32 stream: %d bytes", len(src)))
+	}
+	n := len(src) / sizeOfUint32
+	if cap(dst) < n {
+		dst = make([]uint32, n)
+	}
+	dst = dst[:n]
+	if n == 0 {
+		return dst
+	}
+	if n <= smallCopyWords {
+		for i := range dst {
+			dst[i] = binary.LittleEndian.Uint32(src[i*sizeOfUint32:])
+		}
+		return dst
+	}
+	copy(unsafe.Slice((*byte)(unsafe.Pointer(&dst[0])), n*sizeOfUint32), src)
+	return dst
+}
+
+// copyAsUints64 reinterprets dst as bytes and bulk-copies src into it.
+// Panics if len(src) is not a multiple of the word size (see copyAsUints32).
+func copyAsUints64(src []byte, dst []uint64) []uint64 {
+	if len(src)%8 != 0 {
+		panic(fmt.Sprintf("packer: ragged uint64 stream: %d bytes", len(src)))
+	}
+	n := len(src) / 8
+	if cap(dst) < n {
+		dst = make([]uint64, n)
+	}
+	dst = dst[:n]
+	if n == 0 {
+		return dst
+	}
+	if n <= smallCopyWords {
+		for i := range dst {
+			dst[i] = binary.LittleEndian.Uint64(src[i*8:])
+		}
+		return dst
+	}
+	copy(unsafe.Slice((*byte)(unsafe.Pointer(&dst[0])), n*8), src)
+	return dst
+}

--- a/packer/copy_uints_be.go
+++ b/packer/copy_uints_be.go
@@ -1,0 +1,43 @@
+// Big-endian fallback: element-wise little-endian decode with the same
+// contract as the bulk-copy variant (including the ragged-length panic).
+// No release target or CI runs big-endian, so this path is not exercised
+// by any automated build.
+
+//go:build !(386 || amd64 || arm || arm64 || loong64 || mipsle || mips64le || ppc64le || riscv64 || wasm)
+
+package packer
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+func copyAsUints32(src []byte, dst []uint32) []uint32 {
+	if len(src)%sizeOfUint32 != 0 {
+		panic(fmt.Sprintf("packer: ragged uint32 stream: %d bytes", len(src)))
+	}
+	n := len(src) / sizeOfUint32
+	if cap(dst) < n {
+		dst = make([]uint32, n)
+	}
+	dst = dst[:n]
+	for i := range dst {
+		dst[i] = binary.LittleEndian.Uint32(src[i*sizeOfUint32:])
+	}
+	return dst
+}
+
+func copyAsUints64(src []byte, dst []uint64) []uint64 {
+	if len(src)%8 != 0 {
+		panic(fmt.Sprintf("packer: ragged uint64 stream: %d bytes", len(src)))
+	}
+	n := len(src) / 8
+	if cap(dst) < n {
+		dst = make([]uint64, n)
+	}
+	dst = dst[:n]
+	for i := range dst {
+		dst[i] = binary.LittleEndian.Uint64(src[i*8:])
+	}
+	return dst
+}

--- a/packer/copy_uints_test.go
+++ b/packer/copy_uints_test.go
@@ -1,0 +1,430 @@
+package packer
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math/rand/v2"
+	"testing"
+	"unsafe"
+)
+
+// Reference implementations — the element-wise loops used before the memcpy
+// change (introduced with the packer in #328). Kept in tests as the
+// differential oracle: on little-endian targets the bulk copy must be
+// byte-for-byte equivalent to the LE-decode loop.
+
+func refCopyAsUints32(src []byte, dst []uint32) []uint32 {
+	dst = dst[:0]
+	for len(src) != 0 {
+		dst = append(dst, binary.LittleEndian.Uint32(src))
+		src = src[sizeOfUint32:]
+	}
+	return dst
+}
+
+func refCopyAsUints64(src []byte, dst []uint64) []uint64 {
+	dst = dst[:0]
+	for len(src) != 0 {
+		dst = append(dst, binary.LittleEndian.Uint64(src))
+		src = src[8:]
+	}
+	return dst
+}
+
+func TestCopyAsUintsMatchesReference(t *testing.T) {
+	r := rand.New(rand.NewPCG(1, 2))
+	sizes := []int{0, 1, 2, 7, 8, 9, 16, 127, 128, 129, 512, 4095, 4096}
+
+	// Larger backing buffer so src can start at any byte offset: block payload
+	// begins at +4 after the uint32 header in the real stream, and memmove
+	// must handle every alignment.
+	backing := make([]byte, 4096*8+16)
+	for i := range backing {
+		backing[i] = byte(r.Uint32())
+	}
+
+	for _, words := range sizes {
+		for offset := 0; offset < 8; offset++ {
+			src := backing[offset : offset+words*8]
+
+			// dst modes: nil, undersized, exact, oversized with garbage.
+			dsts64 := [][]uint64{
+				nil,
+				make([]uint64, 0, words/2),
+				make([]uint64, 0, words),
+				append(make([]uint64, 0, words+7), 0xDEAD, 0xBEEF)[:2],
+			}
+			want64 := refCopyAsUints64(src, nil)
+			for i, dst := range dsts64 {
+				got := copyAsUints64(src, dst)
+				if len(got) != len(want64) {
+					t.Fatalf("u64 words=%d offset=%d dst#%d: len %d != %d", words, offset, i, len(got), len(want64))
+				}
+				for j := range got {
+					if got[j] != want64[j] {
+						t.Fatalf("u64 words=%d offset=%d dst#%d: mismatch at %d", words, offset, i, j)
+					}
+				}
+			}
+
+			src32 := backing[offset : offset+words*4]
+			dsts32 := [][]uint32{
+				nil,
+				make([]uint32, 0, words/2),
+				make([]uint32, 0, words),
+				append(make([]uint32, 0, words+7), 0xDEAD, 0xBEEF)[:2],
+			}
+			want32 := refCopyAsUints32(src32, nil)
+			for i, dst := range dsts32 {
+				got32 := copyAsUints32(src32, dst)
+				if len(got32) != len(want32) {
+					t.Fatalf("u32 words=%d offset=%d dst#%d: len %d != %d", words, offset, i, len(got32), len(want32))
+				}
+				for j := range got32 {
+					if got32[j] != want32[j] {
+						t.Fatalf("u32 words=%d offset=%d dst#%d: mismatch at %d", words, offset, i, j)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestCopyAsUintsRaggedPanics pins the fail-fast contract: input whose length
+// is not a multiple of the word size means a corrupted stream and panics, the
+// same way the element-wise decode did (out-of-range on the short tail). All
+// production callers validate the length before slicing.
+func TestCopyAsUintsRaggedPanics(t *testing.T) {
+	mustPanic := func(name string, f func()) {
+		t.Helper()
+		defer func() {
+			if recover() == nil {
+				t.Fatalf("%s: expected panic on ragged input", name)
+			}
+		}()
+		f()
+	}
+	src := make([]byte, 20)
+	mustPanic("u64", func() { copyAsUints64(src, nil) })
+	mustPanic("u32", func() { copyAsUints32(src[:19], nil) })
+}
+
+func FuzzCopyAsUints64(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	f.Add(bytes.Repeat([]byte{0xFF}, 8*129))
+	f.Fuzz(func(t *testing.T, b []byte) {
+		n := len(b) / 8 * 8
+		want := refCopyAsUints64(b[:n], nil)
+		got := copyAsUints64(b[:n], nil)
+		if len(got) != len(want) {
+			t.Fatalf("len %d != %d", len(got), len(want))
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("mismatch at %d", i)
+			}
+		}
+	})
+}
+
+func FuzzCopyAsUints32(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{1, 2, 3, 4})
+	f.Fuzz(func(t *testing.T, b []byte) {
+		n := len(b) / 4 * 4
+		want := refCopyAsUints32(b[:n], nil)
+		got := copyAsUints32(b[:n], nil)
+		if len(got) != len(want) {
+			t.Fatalf("len %d != %d", len(got), len(want))
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("mismatch at %d", i)
+			}
+		}
+	})
+}
+
+// TestDecompressBoundarySizes exercises the Decompress round-trip at the
+// intcomp sub-block boundaries, where the raw-residual path (the copy IS the
+// whole decode) switches over to the bitpacked path.
+func TestDecompressBoundarySizes(t *testing.T) {
+	r := rand.New(rand.NewPCG(9, 9))
+	for _, n := range []int{0, 1, 63, 127, 128, 129, 255, 256, 257, 4096} {
+		vals32 := make([]uint32, n)
+		vals64 := make([]uint64, n)
+		v32, v64 := uint32(0), uint64(0)
+		for i := 0; i < n; i++ {
+			v32 += r.Uint32N(64)
+			v64 += uint64(r.Uint32N(1 << 24))
+			vals32[i] = v32
+			vals64[i] = v64
+		}
+
+		data32 := CompressDeltaBitpackUint32(nil, vals32, nil)
+		_, got32, err := DecompressDeltaBitpackUint32(data32, nil, nil)
+		if err != nil {
+			t.Fatalf("u32 n=%d: %v", n, err)
+		}
+		if len(got32) != n {
+			t.Fatalf("u32 n=%d: got %d values", n, len(got32))
+		}
+		for i := range got32 {
+			if got32[i] != vals32[i] {
+				t.Fatalf("u32 n=%d: mismatch at %d", n, i)
+			}
+		}
+
+		data64 := CompressDeltaBitpackUint64(nil, vals64, nil)
+		_, got64, err := DecompressDeltaBitpackUint64(data64, nil, nil)
+		if err != nil {
+			t.Fatalf("u64 n=%d: %v", n, err)
+		}
+		if len(got64) != n {
+			t.Fatalf("u64 n=%d: got %d values", n, len(got64))
+		}
+		for i := range got64 {
+			if got64[i] != vals64[i] {
+				t.Fatalf("u64 n=%d: mismatch at %d", n, i)
+			}
+		}
+	}
+}
+
+// Benchmarks: variant=loop is the pre-change element-wise decode, variant=memcpy
+// is the production implementation. Sizes reflect the real streams:
+//   512w  = 4 KiB   — compressed LID-block scale;
+//   1456w = 11.4 KiB — compressed MID-block stream (nanosecond MIDs, bitlen≈23);
+//   4096w = 32 KiB  — a fully raw 4096-value block (upper bound).
+func benchCopySizes() []struct {
+	name  string
+	words int
+} {
+	return []struct {
+		name  string
+		words int
+	}{
+		{"512w", 512},
+		{"1456w", 1456},
+		{"4096w", 4096},
+	}
+}
+
+// indexedCopyAsUints64 is the safe-Go middle ground: the element-wise decode
+// with indexed writes instead of append. Benchmarked to attribute the win
+// honestly: how much comes from removing append bookkeeping vs from memmove.
+func indexedCopyAsUints64(src []byte, dst []uint64) []uint64 {
+	n := len(src) / 8
+	if cap(dst) < n {
+		dst = make([]uint64, n)
+	}
+	dst = dst[:n]
+	for i := 0; i < n; i++ {
+		dst[i] = binary.LittleEndian.Uint64(src[i*8 : i*8+8])
+	}
+	return dst
+}
+
+func BenchmarkCopyAsUints64(b *testing.B) {
+	r := rand.New(rand.NewPCG(3, 4))
+	for _, sz := range benchCopySizes() {
+		src := make([]byte, sz.words*8)
+		for i := range src {
+			src[i] = byte(r.Uint32())
+		}
+		b.Run("variant=loop/size="+sz.name, func(b *testing.B) {
+			dst := make([]uint64, 0, sz.words)
+			b.SetBytes(int64(len(src)))
+			for i := 0; i < b.N; i++ {
+				dst = refCopyAsUints64(src, dst)
+			}
+		})
+		b.Run("variant=indexed/size="+sz.name, func(b *testing.B) {
+			dst := make([]uint64, 0, sz.words)
+			b.SetBytes(int64(len(src)))
+			for i := 0; i < b.N; i++ {
+				dst = indexedCopyAsUints64(src, dst)
+			}
+		})
+		b.Run("variant=memcpy/size="+sz.name, func(b *testing.B) {
+			dst := make([]uint64, 0, sz.words)
+			b.SetBytes(int64(len(src)))
+			for i := 0; i < b.N; i++ {
+				dst = copyAsUints64(src, dst)
+			}
+		})
+	}
+}
+
+func BenchmarkCopyAsUints32(b *testing.B) {
+	r := rand.New(rand.NewPCG(5, 6))
+	for _, sz := range benchCopySizes() {
+		src := make([]byte, sz.words*4)
+		for i := range src {
+			src[i] = byte(r.Uint32())
+		}
+		b.Run("variant=loop/size="+sz.name, func(b *testing.B) {
+			dst := make([]uint32, 0, sz.words)
+			b.SetBytes(int64(len(src)))
+			for i := 0; i < b.N; i++ {
+				dst = refCopyAsUints32(src, dst)
+			}
+		})
+		b.Run("variant=memcpy/size="+sz.name, func(b *testing.B) {
+			dst := make([]uint32, 0, sz.words)
+			b.SetBytes(int64(len(src)))
+			for i := 0; i < b.N; i++ {
+				dst = copyAsUints32(src, dst)
+			}
+		})
+	}
+}
+
+// BenchmarkDecompressLIDBlock is the end-to-end regression guard for the LID
+// path: a full 65536-entry postings block of ascending uint32 LIDs with
+// realistic gaps (a ~3% token) through the full Decompress.
+func BenchmarkDecompressLIDBlock(b *testing.B) {
+	r := rand.New(rand.NewPCG(11, 12))
+	lids := make([]uint32, 65536)
+	v := uint32(0)
+	for i := range lids {
+		v += 1 + r.Uint32N(60) // avg gap ~30
+		lids[i] = v
+	}
+	data := CompressDeltaBitpackUint32(nil, lids, nil)
+
+	// Pre-sized buffers model the production callers, which pass pooled
+	// buffers with adequate capacity (lids/seqids unpack buffers).
+	buf := make([]uint32, 0, 65536)
+	compressed := make([]uint32, 0, 65536)
+	b.SetBytes(65536 * 4)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var err error
+		_, buf, err = DecompressDeltaBitpackUint32(data, buf, compressed)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	if buf[0] != lids[0] || buf[65535] != lids[65535] {
+		b.Fatal("bad roundtrip")
+	}
+}
+
+// BenchmarkDecompressSmallBlock covers small streams, where the raw-residual
+// path dominates (values below one intcomp sub-block are stored verbatim, so
+// the byte->word copy IS most of the decode). In production small streams come
+// from the offsets arrays of blocks dominated by a single heavy token, the
+// tail block of every fraction, and freshly sealed small fractions — NOT from
+// short per-token postings: LID blocks are shared containers holding many
+// tokens' lists (lids.Block{LIDs, Offsets}).
+func BenchmarkDecompressSmallBlock(b *testing.B) {
+	r := rand.New(rand.NewPCG(13, 14))
+	for _, n := range []int{1, 16, 127} {
+		vals := make([]uint32, n)
+		v := uint32(0)
+		for i := range vals {
+			v += 1 + r.Uint32N(1000)
+			vals[i] = v
+		}
+		data := CompressDeltaBitpackUint32(nil, vals, nil)
+		b.Run("n="+itoa(n), func(b *testing.B) {
+			buf := make([]uint32, 0, 256)
+			compressed := make([]uint32, 0, 256)
+			b.SetBytes(int64(n) * 4)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var err error
+				_, buf, err = DecompressDeltaBitpackUint32(data, buf, compressed)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func itoa(v int) string {
+	s := ""
+	for v > 0 {
+		s = string(rune('0'+v%10)) + s
+		v /= 10
+	}
+	if s == "" {
+		s = "0"
+	}
+	return s
+}
+
+// rawMemmoveUints64 is the unconditional memmove path (no small-input loop) —
+// test-only, used by BenchmarkSmallCopyCrossover to locate the loop/memmove
+// crossover that sets smallCopyWords.
+func rawMemmoveUints64(src []byte, dst []uint64) []uint64 {
+	n := len(src) / 8
+	if cap(dst) < n {
+		dst = make([]uint64, n)
+	}
+	dst = dst[:n]
+	if n == 0 {
+		return dst
+	}
+	copy(unsafe.Slice((*byte)(unsafe.Pointer(&dst[0])), n*8), src)
+	return dst
+}
+
+// BenchmarkSmallCopyCrossover justifies the smallCopyWords threshold: the
+// element-wise loop vs the unconditional memmove on tiny inputs.
+func BenchmarkSmallCopyCrossover(b *testing.B) {
+	r := rand.New(rand.NewPCG(21, 22))
+	src := make([]byte, 32*8)
+	for i := range src {
+		src[i] = byte(r.Uint32())
+	}
+	for _, words := range []int{1, 2, 4, 6, 8, 12, 16, 24, 32} {
+		s := src[:words*8]
+		b.Run("variant=loop/w="+itoa(words), func(b *testing.B) {
+			dst := make([]uint64, 0, words)
+			for i := 0; i < b.N; i++ {
+				dst = refCopyAsUints64(s, dst)
+			}
+		})
+		b.Run("variant=memmove/w="+itoa(words), func(b *testing.B) {
+			dst := make([]uint64, 0, words)
+			for i := 0; i < b.N; i++ {
+				dst = rawMemmoveUints64(s, dst)
+			}
+		})
+	}
+}
+
+// BenchmarkDecompressMIDBlock is the end-to-end regression guard for the MID
+// path: a realistic 4096-value block of nanosecond MIDs (descending, ~3.6ms
+// steps -> zigzag deltas, bitlen≈23) through the full Decompress.
+func BenchmarkDecompressMIDBlock(b *testing.B) {
+	r := rand.New(rand.NewPCG(7, 8))
+	mids := make([]uint64, 4096)
+	cur := uint64(1_754_600_000_000_000_000) // unix nanos scale
+	for i := range mids {
+		mids[i] = cur
+		cur -= 3_400_000 + r.Uint64N(400_000) // 3.4-3.8ms in nanos
+	}
+	data := CompressDeltaBitpackUint64(nil, mids, nil)
+
+	// Pre-sized buffers model the production callers (seqids unpackCache
+	// allocates values/tmp with IDsPerBlock capacity).
+	buf := make([]uint64, 0, 4096)
+	compressed := make([]uint64, 0, 4096)
+	b.SetBytes(4096 * 8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var err error
+		_, buf, err = DecompressDeltaBitpackUint64(data, buf, compressed)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	if buf[0] != mids[0] || buf[4095] != mids[4095] {
+		b.Fatal("bad roundtrip")
+	}
+}

--- a/packer/delta_bitpacker.go
+++ b/packer/delta_bitpacker.go
@@ -188,20 +188,5 @@ func DecompressDeltaBitpackUint64(data []byte, buf, compressed []uint64) ([]byte
 	return data, buf, nil
 }
 
-func copyAsUints32(src []byte, dst []uint32) []uint32 {
-	dst = dst[:0]
-	for len(src) != 0 {
-		dst = append(dst, binary.LittleEndian.Uint32(src))
-		src = src[sizeOfUint32:]
-	}
-	return dst
-}
-
-func copyAsUints64(src []byte, dst []uint64) []uint64 {
-	dst = dst[:0]
-	for len(src) != 0 {
-		dst = append(dst, binary.LittleEndian.Uint64(src))
-		src = src[8:]
-	}
-	return dst
-}
+// copyAsUints32 and copyAsUints64 convert the little-endian byte stream into
+// words; see copy_uints.go (little-endian targets only, bulk copy).


### PR DESCRIPTION
# perf: bulk-copy bitpacked streams instead of element-wise decode

## Description

`DecompressDeltaBitpack{Uint16,Uint32,Uint64}` convert the compressed stream from bytes to words with a per-element `binary.LittleEndian` loop (`copyAsUints32/64`). The loop is instruction-bound at ~4.5 GiB/s regardless of input size. On little-endian hosts the in-memory representation of a `[]uint32`/`[]uint64` is exactly the on-disk little-endian stream, so the conversion can be a single bulk `copy` (`runtime.memmove`), which runs at memory/cache bandwidth (30–70 GiB/s).

The implementations are split by build tag: bulk copy on every little-endian GOARCH (`copy_uints.go`), the element-wise reference on big-endian (`copy_uints_be.go`) — behavior for BE builds is unchanged. The smallest inputs (≤3 words) keep the plain loop on the LE path too: the crossover was measured (`BenchmarkSmallCopyCrossover` — the loop wins at 1–2 words, memmove wins from 4 on, −48% at 8). The fail-fast contract on a corrupted stream is preserved: a ragged length (not a multiple of the word size) panics, exactly as the element-wise decode did.

No format change, no assembly, `CGO_ENABLED`/purego paths untouched.

> **Open question for maintainers:** seq-db ships only little-endian release targets (`.goreleaser.yml`) and has no big-endian CI, so the BE fallback is dead code that nothing exercises. At the same time, as far as we can tell the codebase is currently endian-correct everywhere (all serialization goes through `binary.LittleEndian`; the few unsafe casts are in-memory scratch reuse) — dropping the fallback would introduce the first LE-only assumption. This PR therefore preserves the status quo (package builds everywhere, BE keeps the element-wise reference). Would you prefer to drop `copy_uints_be.go` and let big-endian builds fail at compile time instead? Happy to do either.

### Where this path runs

`DecompressDeltaBitpack*` is the only road from disk bytes to index values:

| Call site | Block type | Hot paths above it |
|---|---|---|
| `seqids/blocks.go` (`BlockMIDs.Unpack`) | MID blocks (u64) | search window borders (2 unpacks per query per fraction), LID→ID resolution of results, time-series aggregation, histogram, **fetch** (`findLIDs` per fetched ID) |
| `lids/block.go` | LID postings (u32, two streams) | every leaf token on LID-block cache miss; blocks are shared containers (`Block{LIDs, Offsets}`) — each unpack converts two streams, and the offsets stream is tiny whenever a block is dominated by one heavy token |
| `token/block_loader.go` (u16/u32) | token blocks | `GetToken`/`Narrow`/`SelectEntries`/`FindContains` on token-block cache miss |

The same loaders serve local sealed fractions, remote (S3) fractions and compaction reads.

Since the nanosecond-MID migration the compressed MID stream is ~36% of the raw block (bitlen≈23), so the conversion was a third of the MID decompression cost (12–18% of `IndexSearch` in profiles).

## Measurements

Conversion microbenchmarks (`benchstat`, n=10, Cascade Lake; arm64/M1 shows the same shape, copy −84%):

| | loop | memcpy | Δ |
|---|---|---|---|
| u64, 11.4 KiB (real MID stream size) | 2388 ns | **160 ns** | **−93.3%** (4.5 → 67.7 GiB/s) |
| u64, 32 KiB (raw block) | 6764 ns | 955 ns | −85.9% |
| u32, 4 KiB (LID scale) | 850 ns | **31 ns** | **−96.3%** |
| u32, 16 KiB | 6798 ns | 329 ns | −95.2% |

Why not just a better loop? A safe-Go rewrite (indexed writes instead of `append`, `variant=indexed` in the benchmark) gives only **−18%**: any scalar loop moves 8 bytes per iteration, while `memmove` moves cache lines with vector registers (×12 over the indexed loop) — that is what the `unsafe` buys.

Full `Decompress` for every production shape, `main` vs this PR (n=10, pre-sized buffers modeling the production pools):

| Benchmark | main | this PR | Δ |
|---|---|---|---|
| `DecompressMIDBlock` — 4096 nanosecond MIDs, bitlen≈23 | 8.22 µs | 5.93 µs | **−27.9%** |
| `DecompressLIDBlock` — 65536-entry postings block | 79.8 µs | 56.8 µs | **−28.8%** |
| `DecompressSmallBlock/n=127` — raw-residual stream | 254.8 ns | 39.5 ns | **−84.5%** |
| `DecompressSmallBlock/n=16` | 45.6 ns | 24.5 ns | −46.4% |
| `DecompressSmallBlock/n=1` — 2-word stream | 16.0 ns | 19.6 ns | +3.6 ns (+22%) |

Small streams occur in production as the offsets arrays of blocks dominated by one heavy token, the tail block of every fraction, and freshly sealed small fractions (LID blocks are shared multi-token containers, so per-token postings length does not reach this function directly). The `n=1` case regresses by 3.6 ns absolute: the copy helper grew past the inlining budget (the ragged-length check and the two-path body), so the tiny-input call pays a function-call overhead — a few nanoseconds once per block unpack; no search scenario regresses end-to-end (see below); called out here for completeness rather than hidden by the geomean (−44%).

Search-level, this branch vs `main` (in-process harness: sealed fraction, 2M synthetic structured logs, production sealing params; n=10):

| Scenario | main | this PR | Δ |
|---|---|---|---|
| needle-in-haystack, miss (`trace_id:<uuid>`) | 38.80 µs | 37.78 µs | **−2.6%** (p=0.001) |
| needle-in-haystack, hit | 51.27 µs | 47.26 µs | **−7.8%** (p=0.000) |
| `level:error AND service:X`, limit 100 | 382.3 µs | 328.8 µs | **−14.0%** (p=0.000) |
| 3-token AND | 537.2 µs | 525.7 µs | −2.1% (p=0.000) |
| count group by (2M docs) | 287.5 ms | 289.3 ms | +0.6% (p=0.029, noise-level) |
| **fetch, 100 scattered IDs** (`findLIDs` probes a different MID block per ID) | 1.355 ms | 1.144 ms | **−15.6%** (p=0.000) |
| fetch, 100 adjacent IDs | 65.7 µs | 61.8 µs | −5.9% (p=0.000) |
| prefix wildcard (`trace_id:ab*cd*`) | 1.085 ms | 0.979 ms | **−9.8%** (p=0.000) |
| histogram over 2M docs (bulk `GetMIDs`) | 37.9 ms | 36.7 ms | −3.1% (p=0.001) |

The scattered-fetch scenario is the strongest production case: `findLIDs` decompresses ~1.5 MID blocks per fetched ID (54.7% of `Fetch` CPU), and the conversion is a third of that.

## Tests

`packer/copy_uints_test.go`:

- differential test against the reference decode loop: 13 sizes × 8 source offsets (block payload starts at +4 after the uint32 header, so every alignment occurs) × 4 `dst` reuse modes;
- `FuzzCopyAsUints32/64` — differential fuzzing against the reference;
- `TestCopyAsUintsRaggedPanics` — pins the fail-fast contract on corrupted-stream lengths;
- `TestDecompressBoundarySizes` — round-trip at the raw-residual/bitpacked switchover (0, 1, 63, 127, 128, 129, 255, 256, 257, 4096 values, u32 and u64);
- benchmarks: `variant=loop` vs `variant=memcpy` for the conversion, `BenchmarkSmallCopyCrossover` justifying the small-input threshold, plus the end-to-end `Decompress*` regression anchors above.

Verified additionally: full `go test ./...`, `-race` on the affected packages, cross-compilation for the release matrix (linux/darwin × amd64/arm64), wasm and big-endian (`GOARCH=s390x`); byte-identical query results vs `main` on a 57-query equivalence dump (IDs/aggregations/histogram/doc hashes) over the 2M-doc dataset.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [x] I used LLM/AI assistance to make this pull request;

```
Model: Claude (Opus/Fable, agent session)
Prompt: performance research session on cache-aware layouts for seq-db search
structures; this change was found by profiling IndexSearch (phase-0 harness),
implemented and measured by the agent, reviewed by the PR author.
```