### PR TITLE
perf: galloping search in sealed LID iterators' NextGeq

### DIFF
--- a/frac/sealed/lids/gallop.go
+++ b/frac/sealed/lids/gallop.go
@@ -1,0 +1,66 @@
+package lids
+
+// Galloping (exponential) searches for the NextGeq hot path: zigzag targets
+// are monotone and the chunk slice narrows from the consumption edge, so the
+// answer is usually a few elements away from the edge. Probing exponentially
+// from the edge costs ~2*log2(d) for an answer d away (bounded by ~2x a full
+// binary search over the remainder, which pays log2(len) regardless of d).
+
+// searchGeqGallop returns the index of the first element >= t, probing from
+// the front (IteratorDesc consumes the slice front-to-back).
+func searchGeqGallop(a []uint32, t uint32) int {
+	n := len(a)
+	if n == 0 || a[0] >= t {
+		return 0
+	}
+	i := 1
+	for i < n && a[i] < t {
+		i <<= 1
+	}
+	// a[i>>1] < t, so the answer is in (i>>1, min(i, n)].
+	lo := i>>1 + 1
+	hi := i
+	if hi > n {
+		hi = n
+	}
+	for lo < hi {
+		m := int(uint(lo+hi) >> 1)
+		if a[m] < t {
+			lo = m + 1
+		} else {
+			hi = m
+		}
+	}
+	return lo
+}
+
+// searchGtGallopTail returns the index of the first element > t, probing from
+// the back (IteratorAsc consumes the slice back-to-front).
+func searchGtGallopTail(a []uint32, t uint32) int {
+	n := len(a)
+	if n == 0 {
+		return 0
+	}
+	if a[n-1] <= t {
+		return n
+	}
+	i := 1
+	for i < n && a[n-1-i] > t {
+		i <<= 1
+	}
+	// a[n-1-(i>>1)] > t, so the answer is <= n-1-(i>>1) < hi.
+	hi := n - i>>1
+	lo := n - i
+	if lo < 0 {
+		lo = 0
+	}
+	for lo < hi {
+		m := int(uint(lo+hi) >> 1)
+		if a[m] <= t {
+			lo = m + 1
+		} else {
+			hi = m
+		}
+	}
+	return lo
+}

--- a/frac/sealed/lids/gallop_test.go
+++ b/frac/sealed/lids/gallop_test.go
@@ -1,0 +1,31 @@
+package lids
+
+import (
+	"math/rand/v2"
+	"sort"
+	"testing"
+)
+
+func TestGallopAgainstSortSearch(t *testing.T) {
+	r := rand.New(rand.NewPCG(3, 4))
+	for i := 0; i < 200000; i++ {
+		n := 1 + r.IntN(200)
+		a := make([]uint32, n)
+		v := uint32(r.IntN(3))
+		for j := range a {
+			v += uint32(r.IntN(4)) // duplicates allowed
+			a[j] = v
+		}
+		q := uint32(r.IntN(int(v) + 3))
+
+		wantGeq := sort.Search(len(a), func(k int) bool { return a[k] >= q })
+		if got := searchGeqGallop(a, q); got != wantGeq {
+			t.Fatalf("searchGeqGallop(%v, %d) = %d, want %d", a, q, got, wantGeq)
+		}
+
+		wantGt := sort.Search(len(a), func(k int) bool { return a[k] > q })
+		if got := searchGtGallopTail(a, q); got != wantGt {
+			t.Fatalf("searchGtGallopTail(%v, %d) = %d, want %d", a, q, got, wantGt)
+		}
+	}
+}

--- a/frac/sealed/lids/iterator_asc.go
+++ b/frac/sealed/lids/iterator_asc.go
@@ -93,7 +93,7 @@ func (it *IteratorAsc) NextGeq(nextID node.LID) node.LID {
 			continue
 		}
 
-		idx := sort.Search(len(it.lids), func(i int) bool { return it.lids[i] > nextID.Unpack() }) - 1
+		idx := searchGtGallopTail(it.lids, nextID.Unpack()) - 1
 		if idx >= 0 {
 			lid := it.lids[idx]
 			it.lids = it.lids[:idx]
@@ -126,7 +126,7 @@ func (it *IteratorAsc) NextBatchGeq(nextID node.LID) node.LIDBatch {
 			continue
 		}
 
-		idx := sort.Search(len(it.lids), func(i int) bool { return it.lids[i] > nextID.Unpack() }) - 1
+		idx := searchGtGallopTail(it.lids, nextID.Unpack()) - 1
 		if idx >= 0 {
 			batch := it.lids[:idx+1]
 			it.lids = it.lids[:0]

--- a/frac/sealed/lids/iterator_desc.go
+++ b/frac/sealed/lids/iterator_desc.go
@@ -92,7 +92,7 @@ func (it *IteratorDesc) NextGeq(nextID node.LID) node.LID {
 			continue
 		}
 
-		idx := sort.Search(len(it.lids), func(i int) bool { return it.lids[i] >= nextID.Unpack() })
+		idx := searchGeqGallop(it.lids, nextID.Unpack())
 		if idx < len(it.lids) {
 			it.lids = it.lids[idx:]
 			lid := it.lids[0]
@@ -130,7 +130,7 @@ func (it *IteratorDesc) NextBatchGeq(nextID node.LID) node.LIDBatch {
 			continue
 		}
 
-		idx := sort.Search(len(it.lids), func(i int) bool { return it.lids[i] >= nextID.Unpack() })
+		idx := searchGeqGallop(it.lids, nextID.Unpack())
 		if idx < len(it.lids) {
 			batch := it.lids[idx:len(it.lids)]
 			it.lids = it.lids[:0]


### PR DESCRIPTION
# Description

`NextGeq` in the sealed LID iterators runs a binary search over the remaining
chunk slice on every call. The AND/OR zigzag sends monotonically increasing
targets while the slice narrows from the consumption edge, so the answer is
almost always near the edge — instrumented on a 2M-doc fraction: ~50% of calls
land at distance 0 and 99.9% within 16, while binary search pays
log2(remainder) ≈ 14 probes regardless. This PR replaces it with an
exponential (galloping) search from the edge, ~2·log2(d) probes — the same
uncapped scheme as Lucene's
[`IntArrayDocIdSet.advance`](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/util/IntArrayDocIdSet.java)
and RoaringBitmap's
[`advanceUntil`](https://github.com/RoaringBitmap/roaring/blob/master/setutil.go),
which seq-db already depends on for skip masks.

The worst case is bounded at ~2× binary (2·log2(d) ≤ 2·log2(n)) and far jumps
are self-limiting (jumps over one chunk sum to at most its length): an AND
built deliberately from a skewed pair (freq ratio ≈1450, 71% of calls in the
far zone) measures at parity. A capped variant was measured and rejected — it
hurts the common zone and rescues regimes that did not occur across ~6M
instrumented calls (max distance < 128).

Benchstat, n=10, in-process `Sealed.Search`, 2M-doc fraction, vs `main`:

| scenario | diff |
|---|---|
| 3-token AND | **−21.8%** |
| `(a OR b) AND c` | **−10.8%** |
| 2-token AND | **−4.5%** |
| skewed ANDs (ratio ≈285 / ≈1450) | ~ |
| 13 other scenarios (needle hit/miss, aggregations, histogram, wildcard/contains, fetch, active fraction, pure OR, AND NOT) | ~ |

Search results are byte-identical to `main` on a 57-query corpus (IDs and
order in both sort directions, aggregation bins, fetched docs).

Note: `fracmanager/TestCapacityExceeded` is red on current `main` (a73114c)
independently of this change.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [x] I used LLM/AI assistance to make this pull request;

```
Model: Claude Fable 5 (claude-fable-5), via Claude Code
Prompt: interactive session, no single prompt. Task: performance research of
seq-db search internals (profiling, microbenchmarks, adopt/reject verdicts
backed by numbers). Directives shaping this PR: deep-dive galloping; prove
edge-locality with in-engine instrumentation rather than synthetic tests;
write a standalone PR with edge-case/regression justification and prior-art links
Extent: code (gallop.go, test, call sites), benchmarks, and this PR text
were AI-generated under the author's direction and review.
```