### PR TITLE
perf: implement wildcard suffix query dedicated path

### DIFF
--- a/config/frac_version.go
+++ b/config/frac_version.go
@@ -34,4 +34,4 @@ const (
 	BinaryDataV6
 )
 
-const CurrentFracVersion = BinaryDataV5
+const CurrentFracVersion = BinaryDataV6

--- a/config/frac_version.go
+++ b/config/frac_version.go
@@ -34,4 +34,4 @@ const (
 	BinaryDataV6
 )
 
-const CurrentFracVersion = BinaryDataV6
+const CurrentFracVersion = BinaryDataV5

--- a/frac/active_token_list.go
+++ b/frac/active_token_list.go
@@ -53,6 +53,21 @@ func (tp *activeTokenProvider) FindContains(needle []byte) ([]uint32, error) {
 	return tids, nil
 }
 
+// FindSuffix finds tids of tokens which end with a provided suffix.
+func (tp *activeTokenProvider) FindSuffix(suffix []byte) ([]uint32, error) {
+	if len(suffix) == 0 {
+		return nil, nil
+	}
+	var tids []uint32
+	for tid := tp.FirstTID(); tid <= tp.LastTID(); tid++ {
+		token := tp.GetToken(tid)
+		if len(token) >= len(suffix) && bytes.Equal(token[len(token)-len(suffix):], suffix) {
+			tids = append(tids, tid)
+		}
+	}
+	return tids, nil
+}
+
 // FindToken finds tids of tokens which suffice a provided searcher (predicate).
 func (tp *activeTokenProvider) FindToken(searcher pattern.Searcher) ([]uint32, error) {
 	firstTID := searcher.FirstTID()

--- a/frac/sealed/token/block_loader.go
+++ b/frac/sealed/token/block_loader.go
@@ -262,6 +262,49 @@ func (b *Block) containsV5(from, to int, needle []byte) ([]int, error) {
 	return indexes, nil
 }
 
+func (b *Block) suffix(from, to int, suffix []byte) ([]int, error) {
+	if b.FracVer >= config.BinaryDataV6 {
+		return b.suffixV6(from, to, suffix), nil
+	}
+
+	return b.suffixV5(from, to, suffix), nil
+}
+
+// TODO(cheb0) delete this when Block.FracVer is deleted
+func (b *Block) suffixV5(from, to int, suffix []byte) []int {
+	indexes := make([]int, 0)
+	suffixLen := len(suffix)
+
+	for i := from; i <= to; i++ {
+		token := b.GetToken(i)
+		if len(token) >= suffixLen && bytes.Equal(token[len(token)-suffixLen:], suffix) {
+			indexes = append(indexes, i)
+		}
+	}
+
+	return indexes
+}
+
+func (b *Block) suffixV6(from int, to int, suffix []byte) []int {
+	indexes := make([]int, 0)
+	suffixLen := uint32(len(suffix))
+
+	offsets := b.Offsets[from : to+2]
+
+	for i := 1; i < len(offsets); i++ {
+		endPos := offsets[i]
+		tokLen := endPos - offsets[i-1]
+		if tokLen >= suffixLen {
+			tokSuffix := b.Payload[endPos-suffixLen : endPos]
+			if bytes.Equal(tokSuffix, suffix) {
+				indexes = append(indexes, from+i-1)
+			}
+		}
+	}
+
+	return indexes
+}
+
 func (b *Block) find(from, to int, searcher pattern.Searcher) ([]int, error) {
 	indexes := make([]int, 0)
 	for i := from; i <= to; i++ {

--- a/frac/sealed/token/block_loader.go
+++ b/frac/sealed/token/block_loader.go
@@ -285,7 +285,7 @@ func (b *Block) suffixV5(from, to int, suffix []byte) []int {
 	return indexes
 }
 
-func (b *Block) suffixV6(from int, to int, suffix []byte) []int {
+func (b *Block) suffixV6(from, to int, suffix []byte) []int {
 	indexes := make([]int, 0)
 	suffixLen := uint32(len(suffix))
 

--- a/frac/sealed/token/provider.go
+++ b/frac/sealed/token/provider.go
@@ -74,6 +74,20 @@ func (tp *Provider) FindContains(needle []byte) ([]uint32, error) {
 		})
 }
 
+func (tp *Provider) FindSuffix(suffix []byte) ([]uint32, error) {
+	requiredLetters := util.NewLettersBitset(suffix)
+
+	return tp.findInBlocks(
+		tp.FirstTID(),
+		tp.LastTID(),
+		func(e *TableEntry) bool {
+			return e.Letters.IsNil() || e.Letters.ContainsAll(requiredLetters)
+		},
+		func(b *Block, firstIndex, lastIndex int) ([]int, error) {
+			return b.suffix(firstIndex, lastIndex, suffix)
+		})
+}
+
 func (tp *Provider) FindToken(searcher pattern.Searcher) ([]uint32, error) {
 	return tp.findInBlocks(
 		searcher.FirstTID(),

--- a/pattern/pattern.go
+++ b/pattern/pattern.go
@@ -18,6 +18,7 @@ import (
 type tokenProvider interface {
 	GetToken(uint32) []byte
 	FindContains(needle []byte) ([]uint32, error)
+	FindSuffix(suffix []byte) ([]uint32, error)
 	FindToken(searcher Searcher) ([]uint32, error)
 	FirstTID() uint32
 	LastTID() uint32
@@ -528,12 +529,27 @@ func isSimpleWildcardContains(token parser.Token) (needle []byte, ok bool) {
 	return []byte(lit.Terms[1].Data), true
 }
 
+// isSimpleWildcardSuffix checks if this AST token is simple wildcard like '*abc'
+func isSimpleWildcardSuffix(token parser.Token) (suffix []byte, ok bool) {
+	lit, ok := token.(*parser.Literal)
+	if !ok || len(lit.Terms) != 2 {
+		return nil, false
+	}
+	if !lit.Terms[0].IsWildcard() || lit.Terms[1].Kind != parser.TermText {
+		return nil, false
+	}
+	return []byte(lit.Terms[1].Data), true
+}
+
 func Search(ctx context.Context, t parser.Token, tp tokenProvider) ([]uint32, error) {
 	if util.IsCancelled(ctx) {
 		return nil, ctx.Err()
 	}
 	if needle, ok := isSimpleWildcardContains(t); ok {
 		return tp.FindContains(needle)
+	}
+	if suffix, ok := isSimpleWildcardSuffix(t); ok {
+		return tp.FindSuffix(suffix)
 	}
 	s := newSearcher(t, tp)
 	return tp.FindToken(s)

--- a/pattern/pattern_test.go
+++ b/pattern/pattern_test.go
@@ -116,6 +116,20 @@ func (tp *simpleTokenProvider) FindContains(needle []byte) ([]uint32, error) {
 	return tids, nil
 }
 
+func (tp *simpleTokenProvider) FindSuffix(suffix []byte) ([]uint32, error) {
+	if len(suffix) == 0 {
+		return nil, nil
+	}
+	var tids []uint32
+	for t := tp.FirstTID(); t <= tp.LastTID(); t++ {
+		token := tp.GetToken(t)
+		if len(token) >= len(suffix) && bytes.Equal(token[len(token)-len(suffix):], suffix) {
+			tids = append(tids, t)
+		}
+	}
+	return tids, nil
+}
+
 func (tp *simpleTokenProvider) FindToken(searcher Searcher) ([]uint32, error) {
 	firstTID := searcher.FirstTID()
 	lastTID := searcher.LastTID()
@@ -346,6 +360,28 @@ func TestPatternSuffix2(t *testing.T) {
 		{"aba*caba", []string{"abacaba"}},
 		{"abac*caba", []string{}},
 		{"*caba", []string{"abacaba", "caba"}},
+	}
+
+	testAll(t, tp, tests)
+}
+
+func TestPatternSuffixOnly(t *testing.T) {
+	tp := newTestTokenProvider([]string{
+		"abc",
+		"xabc",
+		"xyabc",
+		"xyzabc",
+		"abcx",
+		"xabcx",
+		"notabc",
+		"nothing",
+	})
+
+	tests := []testCase{
+		{"*abc", []string{"abc", "notabc", "xabc", "xyabc", "xyzabc"}},
+		{"*x", []string{"abcx", "xabcx"}},
+		{"*ng", []string{"nothing"}},
+		{"*g", []string{"nothing"}},
 	}
 
 	testAll(t, tp, tests)


### PR DESCRIPTION
# Description

Same optimization as for `contains`.

### V5 fractions

<!DOCTYPE html>

<html>
<body>

Query | env | Total | cold, ms |   | hot, ms |   | cold (branch), ms |   | hot (branch), ms |   | cold diff | hot diff
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
message:*container_show_item | prod | 0 | 93.69 | ±1.89 | 5.39 | ±0.10 | 84.15 | ±2.91 | 3.32 | ±0.05 | -10.2% | -38.4%
request:*201928699403000 | prod | 0 | 119.26 | ±5.94 | 15.4 | ±0.28 | 108.03 | ±6.04 | 10.1 | ±0.05 | -9.4% | -34.4%


</body>

</html>


### V6 fractions

<!DOCTYPE html>

<html>
<body>

Query | env | Total | cold, ms |   | hot, ms |   | cold (branch), ms |   | hot (branch), ms |   | cold diff | hot diff
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
message:*container_show_item | prod | 0 | 93.69 | ±1.89 | 5.39 | ±0.10 | 79.21 | ±2.66 | 2.18 | ±0.08 | -15.5% | -59.6%
request:*201928699403000 | prod | 0 | 119.26 | ±5.94 | 15.4 | ±0.28 | 96.12 | ±7.44 | 7.66 | ±0.22 | -19.4% | -50.3%


</body>

</html>


---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>