### PR TITLE
perf: rewrite `field:*` to `_exists_:field`

### DIFF
--- a/parser/seqql_filter.go
+++ b/parser/seqql_filter.go
@@ -125,13 +125,17 @@ func parseFulltextSearchFilter(lex *lexer, fieldName string, t seq.TokenizerType
 		if err != nil {
 			return nil, fmt.Errorf("parsing keyword for field %q: %s", fieldName, err)
 		}
-		return &ASTNode{Value: &Literal{Field: fieldName, Terms: terms}}, nil
+
+		lit := Literal{Field: fieldName, Terms: terms}
+		return &ASTNode{Value: lit.Optimize()}, nil
+
 	case seq.TokenizerTypeText:
 		tokens, err := parseSeqQLText(fieldName, value, caseSensitive)
 		if err != nil {
 			return nil, fmt.Errorf("parsing text for field %q: %s", fieldName, err)
 		}
 		return buildAndTree(tokens), nil
+
 	default:
 		panic(fmt.Errorf("BUG: unexpected index type: %d", t))
 	}
@@ -288,8 +292,12 @@ func parseSeqQLKeyword(token string, caseSensitive bool) ([]Term, error) {
 
 func parseSeqQLText(field, token string, sensitive bool) ([]Token, error) {
 	if token == "" {
-		return []Token{&Literal{Field: field, Terms: []Term{newTextTerm("")}}}, nil
+		return []Token{&Literal{
+			Field: field,
+			Terms: []Term{newTextTerm("")}},
+		}, nil
 	}
+
 	var tokens []Token
 	current := &Literal{Field: field}
 
@@ -318,17 +326,19 @@ func parseSeqQLText(field, token string, sensitive bool) ([]Token, error) {
 		// So create new literal.
 
 		if len(current.Terms) != 0 {
-			tokens = append(tokens, current)
+			tokens = append(tokens, current.Optimize())
 			current = &Literal{Field: field}
 		}
+
 		token = token[size:]
 	}
+
 	if term.Data != "" {
 		current.appendTerm(term, sensitive)
 	}
 
 	if current != nil && len(current.Terms) > 0 {
-		tokens = append(tokens, current)
+		tokens = append(tokens, current.Optimize())
 	}
 
 	if len(tokens) == 0 {
@@ -338,5 +348,6 @@ func parseSeqQLText(field, token string, sensitive bool) ([]Token, error) {
 			Terms: []Term{{Kind: TermText, Data: ""}},
 		})
 	}
+
 	return tokens, nil
 }

--- a/parser/seqql_filter_test.go
+++ b/parser/seqql_filter_test.go
@@ -76,6 +76,7 @@ func TestSeqQLAll(t *testing.T) {
 	test("*", "*")
 	test("((*))", "*")
 	test("((*) OR service:foo) AND service:bar", "((* or service:foo) and service:bar)")
+	test("_exists_:*", "_exists_:*")
 
 	// Propagate "not".
 	test(`NOT NOT text:a`, `text:a`)

--- a/parser/seqql_filter_test.go
+++ b/parser/seqql_filter_test.go
@@ -106,7 +106,7 @@ func TestSeqQLAll(t *testing.T) {
 	test(`service:"some*thing*"`, `service:some*thing*`)
 	test(`service:some*thing*`, `service:some*thing*`)
 	test(`service:*thing*`, `service:*thing*`)
-	test(`service:"*"`, `service:*`)
+	test(`service:"*"`, `_exists_:service`)
 	test(`service:"cms"*"inter"*"api"`, `service:cms*inter*api`)
 
 	// Test keyword wildcards.
@@ -129,7 +129,7 @@ func TestSeqQLAll(t *testing.T) {
 	test(`keyword:'#''$'"^"`, `keyword:"#$^"`)
 	test(`message:'#''$'"^"`, `message:""`)
 	test(`'#':'#'`, `"#":"#"`)
-	test(`"*":"*"`, `"\*":*`)
+	test(`"*":"*"`, `_exists_:"\*"`)
 	test("`*`:`*`", `"\*":"\*"`)
 	test(`m:a AND OR : r`, `(m:a and "OR":r)`)
 
@@ -143,8 +143,8 @@ func TestSeqQLAll(t *testing.T) {
 	test(`service:a or not service:b or service:c`, `(not (not service:c and (not service:a and service:b)))`)
 	test(`not (service:a or service:c)`, `(not (service:a or service:c))`)
 	test(`NOT Not service:a`, `service:a`)
-	test(`service:*`, `service:*`)
-	test(` service : * `, `service:*`)
+	test(`service:*`, `_exists_:service`)
+	test(` service : * `, `_exists_:service`)
 	test(`service:a or service:b AND NOT service:c`, `(service:a or (not service:c and service:b))`)
 
 	// Test comments.
@@ -162,10 +162,10 @@ service:"wms-svc-logistics-megasort" and level:"#"
 
 	// Test complex search with wildcards.
 	test(`text:"\*\**"`, `text:"\*\*"*`)
-	test(`text:'value=*' AND text:'value="\*"*'`, `((text:value and text:*) and ((text:value and text:"\*") and text:*))`)
-	test(`text:value'="\*\*"*' AND text:"\*\*"`, `(((text:value and text:"\*\*") and text:*) and text:"\*\*")`)
+	test(`text:'value=*' AND text:'value="\*"*'`, `((text:value and _exists_:text) and ((text:value and text:"\*") and _exists_:text))`)
+	test(`text:value'="\*\*"*' AND text:"\*\*"`, `(((text:value and text:"\*\*") and _exists_:text) and text:"\*\*")`)
 	test(`text:'value=*' AND text:'value="\*"*' AND text:'value="\*\*"*' AND text:"\*\*" AND text:"\*\**"`,
-		`(((((text:value and text:*) and ((text:value and text:"\*") and text:*)) and ((text:value and text:"\*\*") and text:*)) and text:"\*\*") and text:"\*\*"*)`)
+		`(((((text:value and _exists_:text) and ((text:value and text:"\*") and _exists_:text)) and ((text:value and text:"\*\*") and _exists_:text)) and text:"\*\*") and text:"\*\*"*)`)
 
 	// Test escape.
 	test("keyword:`+7 995 28 07`", "keyword:\"+7 995 28 07\"")
@@ -215,8 +215,8 @@ service:"wms-svc-logistics-megasort" and level:"#"
 
 	// Test filter 'in'.
 	test(`service:in(auth-api, api-gateway, clickhouse-shard-*)`, `((service:auth-api or service:api-gateway) or service:clickhouse-shard-*)`)
-	test(`service:in(*, *, *)`, `((service:* or service:*) or service:*)`)
-	test(`service:in(*)`, `service:*`)
+	test(`service:in(*, *, *)`, `((_exists_:service or _exists_:service) or _exists_:service)`)
+	test(`service:in(*)`, `_exists_:service`)
 	test(`level:in(1)`, `level:1`)
 	test(`level:in(1, '2', 'three')`, `((level:1 or level:2) or level:three)`)
 	test(`level:in(1, '2', ''*3*"")`, `((level:1 or level:2) or level:*3*)`)

--- a/parser/token_literal.go
+++ b/parser/token_literal.go
@@ -24,6 +24,22 @@ func (n *Literal) DumpSeqQL(o *strings.Builder) {
 	}
 }
 
+func (n *Literal) Optimize() *Literal {
+	// We cannot rewrite _all_:* to _exists_:_all_
+	ok := n.Field != seq.TokenAll &&
+		// We cannot rewrite anything except foo:*
+		(len(n.Terms) == 1 && n.Terms[0].IsWildcard())
+
+	if !ok {
+		return n
+	}
+
+	return &Literal{
+		Field: seq.TokenExists,
+		Terms: []Term{newTextTerm(n.Field)},
+	}
+}
+
 func (n *Literal) appendTerm(term Term, sensitive bool) {
 	if !sensitive {
 		term.Data = strings.ToLower(term.Data)

--- a/parser/token_literal.go
+++ b/parser/token_literal.go
@@ -27,6 +27,8 @@ func (n *Literal) DumpSeqQL(o *strings.Builder) {
 func (n *Literal) Optimize() *Literal {
 	// We cannot rewrite _all_:* to _exists_:_all_
 	ok := n.Field != seq.TokenAll &&
+		// We cannot rewrite _exists_:* to _exists_:_exists_
+		n.Field != seq.TokenExists &&
 		// We cannot rewrite anything except foo:*
 		(len(n.Terms) == 1 && n.Terms[0].IsWildcard())
 

--- a/pattern/pattern_test.go
+++ b/pattern/pattern_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/ozontech/seq-db/parser"
 )
 
+const fieldName = "m"
+
 type testTokenProvider struct {
 	ordered  *simpleTokenProvider
 	shuffled *simpleTokenProvider
@@ -156,15 +158,28 @@ func parseSingleTokenForTests(query string) (parser.Token, error) {
 
 func search(t *testing.T, tp *simpleTokenProvider, req string, expect []string) {
 	searchType := "full"
+
 	if tp.Ordered() {
 		searchType = "narrow"
 	}
 
-	token, err := parseSingleTokenForTests("m:" + req)
+	token, err := parseSingleTokenForTests(fieldName + ":" + req)
 	require.NoError(t, err)
-	s := newSearcher(token, tp)
+
+	// When parsing query we perform following rewrite:
+	//   foo:* --> _exists_:foo
+	// This is workaround for that so we could really
+	// test the pattern checking.
+	if req == "*" {
+		token = &parser.Literal{
+			Field: fieldName,
+			Terms: []parser.Term{{Kind: parser.TermSymbol}},
+		}
+	}
 
 	res := []string{}
+	s := newSearcher(token, tp)
+
 	for i := s.FirstTID(); i <= s.LastTID(); i++ {
 		val := tp.GetToken(i)
 
@@ -177,8 +192,8 @@ func search(t *testing.T, tp *simpleTokenProvider, req string, expect []string) 
 			res = append(res, string(val))
 		}
 	}
-	sort.Strings(res)
 
+	sort.Strings(res)
 	assert.Equal(t, expect, res, "%s search request %q failed", searchType, req)
 }
 


### PR DESCRIPTION
# Description

We can rewrite queries like `trace_id:*` to `_exists_:trace_id` in regular search requests. The latter query is significantly lighter and significantly easier to compute because we have special `_exists_` index type.

This way we do not need to build huge tree of iterators over all possible token values. The following benchmark proves it -- `trace_id` is a high-cardinal field while `k8s_pod` is not:

<table>
  <tr>
    <th rowspan="2">Query</th>
    <th rowspan="2">Type</th>
    <th colspan="3"><code>mean (ms)</code></th>
    <th colspan="3"><code>stddev (ms)</code></th>
    <th colspan="3"><code>p(50) (ms)</code></th>
    <th colspan="3"><code>p(95) (ms)</code></th>
    <th colspan="3"><code>p(99) (ms)</code></th>
    <th colspan="3"><code>iterations</code></th>
    <th colspan="3"><code>total</code></th>
  </tr>
  <tr>
    <th>base</th><th>comp</th><th>diff</th>
    <th>base</th><th>comp</th><th>diff</th>
    <th>base</th><th>comp</th><th>diff</th>
    <th>base</th><th>comp</th><th>diff</th>
    <th>base</th><th>comp</th><th>diff</th>
    <th>base</th><th>comp</th><th>diff</th>
    <th>base</th><th>comp</th><th>diff</th>
  </tr>
  <tr>
    <td rowspan="2"><pre><code>k8s_pod:*</code></pre></td>
    <td>hot</td>
    <td><code>14.79</code></td><td><code>1.33</code></td><td><code>-91.02%</code></td>
    <td><code>1.69</code></td><td><code>0.18</code></td><td><code>-89.12%</code></td>
    <td><code>14.23</code></td><td><code>1.34</code></td><td><code>-90.56%</code></td>
    <td><code>18.74</code></td><td><code>1.60</code></td><td><code>-91.44%</code></td>
    <td><code>46.66</code></td><td><code>31.86</code></td><td><code>-31.72%</code></td>
    <td><code>47</code></td><td><code>47</code></td><td><code>0.00%</code></td>
    <td><code>1019829</code></td><td><code>1019792</code></td><td><code>-0.00%</code></td>
  </tr>
  <tr>
    <td>cold</td>
    <td><code>100.21</code></td><td><code>84.49</code></td><td><code>-15.69%</code></td>
    <td><code>4.85</code></td><td><code>9.72</code></td><td><code>+100.30%</code></td>
    <td><code>99.33</code></td><td><code>82.52</code></td><td><code>-16.92%</code></td>
    <td><code>108.22</code></td><td><code>106.53</code></td><td><code>-1.57%</code></td>
    <td><code>109.86</code></td><td><code>121.06</code></td><td><code>+10.19%</code></td>
    <td><code>27</code></td><td><code>27</code></td><td><code>0.00%</code></td>
    <td><code>1019735</code></td><td><code>1019292</code></td><td><code>-0.04%</code></td>
  </tr>
  <tr>
    <td rowspan="2"><pre><code>trace_id:*</code></pre></td>
    <td>hot</td>
    <td><code>211.08</code></td><td><code>1.38</code></td><td><code>-99.35%</code></td>
    <td><code>4.17</code></td><td><code>0.14</code></td><td><code>-96.64%</code></td>
    <td><code>210.42</code></td><td><code>1.39</code></td><td><code>-99.34%</code></td>
    <td><code>224.59</code></td><td><code>1.63</code></td><td><code>-99.27%</code></td>
    <td><code>256.51</code></td><td><code>31.53</code></td><td><code>-87.71%</code></td>
    <td><code>46</code></td><td><code>47</code></td><td><code>+2.17%</code></td>
    <td><code>1019898</code></td><td><code>1019556</code></td><td><code>-0.03%</code></td>
  </tr>
  <tr>
    <td>cold</td>
    <td><code>336.39</code></td><td><code>77.91</code></td><td><code>-76.84%</code></td>
    <td><code>13.45</code></td><td><code>3.35</code></td><td><code>-75.07%</code></td>
    <td><code>333.31</code></td><td><code>77.47</code></td><td><code>-76.76%</code></td>
    <td><code>360.01</code></td><td><code>92.68</code></td><td><code>-74.26%</code></td>
    <td><code>373.03</code></td><td><code>104.51</code></td><td><code>-71.98%</code></td>
    <td><code>23</code></td><td><code>28</code></td><td><code>+21.74%</code></td>
    <td><code>1019355</code></td><td><code>1019146</code></td><td><code>-0.02%</code></td>
  </tr>
</table>

Also I've [measured](https://comparison.seqbench.ozon.dev/grafana/goto/afw6crfvvtiwwf?orgId=1) impact of this optimization on `search-regular` scenario with query `resource:*`:
- CPU usage: from 2.11 to 0.12 (95%);
- RAM usage: same numbers;

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
