### PR TITLE
fix: pass correct readers for legacy sealed fraction

### DIFF
--- a/frac/sealed_source.go
+++ b/frac/sealed_source.go
@@ -31,9 +31,22 @@ type SealedSource struct {
 func NewSealedSource(f *Sealed) *SealedSource {
 	f.init(true)
 
-	idReader := f.mustGetReader(f.idReaderProvider)
-	lidReader := f.mustGetReader(f.lidReaderProvider)
-	tokenReader := f.mustGetReader(f.tokenReaderProvider)
+	var (
+		tokenReader storage.IndexReader
+		lidReader   storage.IndexReader
+		idReader    storage.IndexReader
+	)
+
+	if f.IsLegacy {
+		legacyReader := f.mustGetReader(f.legacyReaderProvider)
+		tokenReader = legacyReader
+		lidReader = legacyReader
+		idReader = legacyReader
+	} else {
+		tokenReader = f.mustGetReader(f.tokenReaderProvider)
+		lidReader = f.mustGetReader(f.lidReaderProvider)
+		idReader = f.mustGetReader(f.idReaderProvider)
+	}
 
 	return &SealedSource{
 		f: f,


### PR DESCRIPTION
# Description

When trying to compact legacy fractions following panic occurs:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xbb4a17]

goroutine 173 [running]:
github.com/ozontech/seq-db/storage.(*ReaderProvider).GetReader(0x0)
    github.com/ozontech/seq-db/storage/index_reader.go:37 +0x57
github.com/ozontech/seq-db/frac.(*Sealed).mustGetReader(0xc0002a68c0, 0x1602a01?)
    github.com/ozontech/seq-db/frac/sealed.go:283 +0x51
github.com/ozontech/seq-db/frac.NewSealedSource(0xc0002a68c0)
    github.com/ozontech/seq-db/frac/sealed_source.go:34 +0x57
github.com/ozontech/seq-db/compaction.(*Executor).compact(0xc0004a6280, {{0x0, 0xee1e04ee0, 0x2395120}, {0xc000115038, 0x6}, {0xc000244090, 0x27}, 0xc0006e83c0, 0xc0004c0600})
    github.com/ozontech/seq-db/compaction/executor.go:60 +0x2ea
github.com/ozontech/seq-db/compaction.NewExecutor.(*Executor).init.func1()
    github.com/ozontech/seq-db/compaction/executor.go:41 +0x145
sync.(*WaitGroup).Go.func1()
    sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 1
    sync/waitgroup.go:237 +0x73
```

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
