### PR TITLE
fix: set max grpc msg size for proxy

### DIFF
--- a/proxyapi/grpc_server.go
+++ b/proxyapi/grpc_server.go
@@ -55,6 +55,7 @@ func initServer() *grpc.Server {
 	opts := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(interceptors...),
 		grpc.ChainStreamInterceptor(streamInterceptors...),
+		// Proxy can now act like a store, so max msg size is same as for store
 		grpc.MaxRecvMsgSize(int(units.MiB) * 256),
 		grpc.MaxSendMsgSize(int(units.MiB) * 256),
 		grpc.StatsHandler(&tracing.ServerHandler{}),

--- a/proxyapi/grpc_server.go
+++ b/proxyapi/grpc_server.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/alecthomas/units"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	_ "google.golang.org/grpc/encoding/gzip" // Register gzip compressor
@@ -54,6 +55,8 @@ func initServer() *grpc.Server {
 	opts := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(interceptors...),
 		grpc.ChainStreamInterceptor(streamInterceptors...),
+		grpc.MaxRecvMsgSize(int(units.MiB) * 256),
+		grpc.MaxSendMsgSize(int(units.MiB) * 256),
 		grpc.StatsHandler(&tracing.ServerHandler{}),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			MaxConnectionIdle:     time.Minute * 2,

--- a/proxyapi/ingestor.go
+++ b/proxyapi/ingestor.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/alecthomas/units"
 	"github.com/ozontech/seq-db/network/grpcutil"
 	"github.com/ozontech/seq-db/proxy/stores"
 
@@ -117,7 +118,13 @@ func NewIngestor(config IngestorConfig, store *storeapiclient.Store) (*Ingestor,
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &humanReadableMarshaler{}),
 	)
 	err := seqproxyapi.RegisterSeqProxyApiHandlerFromEndpoint(ctx, grpcGateway, config.API.GatewayAddr,
-		[]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())})
+		[]grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithDefaultCallOptions(
+				grpc.MaxCallRecvMsgSize(256*int(units.MiB)),
+				grpc.MaxCallSendMsgSize(256*int(units.MiB)),
+			),
+		})
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("register grpc handler: %s", err)
@@ -144,7 +151,14 @@ func NewIngestor(config IngestorConfig, store *storeapiclient.Store) (*Ingestor,
 
 	var mirror seqproxyapi.SeqProxyApiClient
 	if config.Search.MirrorAddr != "" {
-		conn, err := grpc.NewClient(config.Search.MirrorAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.NewClient(
+			config.Search.MirrorAddr,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithDefaultCallOptions(
+				grpc.MaxCallRecvMsgSize(256*int(units.MiB)),
+				grpc.MaxCallSendMsgSize(256*int(units.MiB)),
+			),
+		)
 		if err != nil {
 			logger.Error("failed to create mirror client", zap.Error(err))
 		} else {

--- a/proxyapi/ingestor.go
+++ b/proxyapi/ingestor.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alecthomas/units"
 	"github.com/ozontech/seq-db/network/grpcutil"
 	"github.com/ozontech/seq-db/proxy/stores"
 
@@ -118,13 +117,7 @@ func NewIngestor(config IngestorConfig, store *storeapiclient.Store) (*Ingestor,
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &humanReadableMarshaler{}),
 	)
 	err := seqproxyapi.RegisterSeqProxyApiHandlerFromEndpoint(ctx, grpcGateway, config.API.GatewayAddr,
-		[]grpc.DialOption{
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithDefaultCallOptions(
-				grpc.MaxCallRecvMsgSize(256*int(units.MiB)),
-				grpc.MaxCallSendMsgSize(256*int(units.MiB)),
-			),
-		})
+		[]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())})
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("register grpc handler: %s", err)
@@ -151,14 +144,7 @@ func NewIngestor(config IngestorConfig, store *storeapiclient.Store) (*Ingestor,
 
 	var mirror seqproxyapi.SeqProxyApiClient
 	if config.Search.MirrorAddr != "" {
-		conn, err := grpc.NewClient(
-			config.Search.MirrorAddr,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithDefaultCallOptions(
-				grpc.MaxCallRecvMsgSize(256*int(units.MiB)),
-				grpc.MaxCallSendMsgSize(256*int(units.MiB)),
-			),
-		)
+		conn, err := grpc.NewClient(config.Search.MirrorAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			logger.Error("failed to create mirror client", zap.Error(err))
 		} else {


### PR DESCRIPTION
# Description

Set max grpc size for proxy. Otherwise high-cardinality agg doesn't work via `curl`. Might also be useful for regions.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;
