### PR TITLE
refactor: swap desc asc node in node package

### DIFF
--- a/cmd/index_analyzer/main.go
+++ b/cmd/index_analyzer/main.go
@@ -173,7 +173,7 @@ func getLIDsHash(tokenLIDs []uint32) [16]byte {
 type noopSkipMaskProvider struct{}
 
 func (noopSkipMaskProvider) GetIDsIteratorByFrac(_ string, _, _ uint32, reverse bool) (node.Node, bool, func() error, error) {
-	return node.NewStatic(nil, reverse), false, func() error { return nil }, nil
+	return node.NewStatic(nil, !reverse), false, func() error { return nil }, nil
 }
 
 func (noopSkipMaskProvider) GetIDsBitmapByFrac(_ string, _, _ uint32) (*roaring.Bitmap, error) {

--- a/frac/active_index.go
+++ b/frac/active_index.go
@@ -232,7 +232,7 @@ func (si *activeSearchIndex) GetSkipLIDs(minLID, maxLID uint32, reverse bool) (n
 	// we need to sort inversed values since they may be out of order after replay of active fraction
 	slices.Sort(res)
 
-	return node.NewStatic(res, reverse), has, release, nil
+	return node.NewStatic(res, !reverse), has, release, nil
 }
 
 type activeTokenIndex struct {
@@ -265,7 +265,7 @@ func (si *activeTokenIndex) GetLIDsFromTIDs(tids []uint32, _ lids.Counter, minLI
 		tlids := si.tokenList.Provide(tid)
 		unmapped := tlids.GetLIDs(si.mids, si.rids)
 		inverse := inverseLIDs(unmapped, si.inverser, minLID, maxLID)
-		nodes = append(nodes, node.NewStatic(inverse, order.IsReverse()))
+		nodes = append(nodes, node.NewStatic(inverse, order.IsDesc()))
 	}
 	return nodes
 }
@@ -276,7 +276,7 @@ func (si *activeTokenIndex) GetBatchedLIDsFromTIDs(tids []uint32, _ lids.Counter
 		tlids := si.tokenList.Provide(tid)
 		unmapped := tlids.GetLIDs(si.mids, si.rids)
 		inverse := inverseLIDs(unmapped, si.inverser, minLID, maxLID)
-		nodes = append(nodes, node.NewStaticBatched(inverse, order.IsReverse()))
+		nodes = append(nodes, node.NewStaticBatched(inverse, order.IsDesc()))
 	}
 	return nodes
 }

--- a/frac/fraction_test.go
+++ b/frac/fraction_test.go
@@ -40,7 +40,7 @@ import (
 type testSkipMaskProvider struct{}
 
 func (testSkipMaskProvider) GetIDsIteratorByFrac(fracName string, minLID, maxLID uint32, reverse bool) (node.Node, bool, func() error, error) {
-	return node.NewStatic([]uint32{}, false), false, func() error { return nil }, nil
+	return node.NewStatic([]uint32{}, true), false, func() error { return nil }, nil
 }
 func (testSkipMaskProvider) GetIDsBitmapByFrac(fracName string, minLID, maxLID uint32) (*roaring.Bitmap, error) {
 	return nil, nil

--- a/frac/processor/aggregator_test.go
+++ b/frac/processor/aggregator_test.go
@@ -32,7 +32,7 @@ func TestSingleSourceCountAggregator(t *testing.T) {
 	iter := NewSourcedNodeIterator(source, nil, nil, "", iteratorLimit{limit: 0, err: consts.ErrTooManyGroupTokens})
 	agg := NewSingleSourceCountAggregator(iter, provideExtractTimeFunc(nil, nil, 0))
 	for _, id := range searchDocs {
-		if err := agg.Next(node.NewDescLID(id)); err != nil {
+		if err := agg.Next(node.NewAscLID(id)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -64,7 +64,7 @@ func TestSingleSourceCountAggregatorWithInterval(t *testing.T) {
 	})
 
 	for _, id := range searchDocs {
-		if err := agg.Next(node.NewDescLID(id)); err != nil {
+		if err := agg.Next(node.NewAscLID(id)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -98,14 +98,14 @@ func BenchmarkAggDeep(b *testing.B) {
 		b.Run(fmt.Sprintf("size=%d", s), func(b *testing.B) {
 			r := rand.New(rand.NewSource(benchRandSeed))
 			v, _ := Generate(r, s)
-			src := node.NewSourcedNodeWrapper(node.NewStatic(v, false), 0)
+			src := node.NewSourcedNodeWrapper(node.NewStatic(v, true), 0)
 			iter := NewSourcedNodeIterator(src, nil, make([]uint32, 1), "", iteratorLimit{limit: 0, err: consts.ErrTooManyGroupTokens})
 			n := NewSingleSourceCountAggregator(iter, provideExtractTimeFunc(nil, nil, 0))
 			vals, _ := Generate(r, s)
 
 			for b.Loop() {
 				for _, v := range vals {
-					if err := n.Next(node.NewDescLID(v)); err != nil {
+					if err := n.Next(node.NewAscLID(v)); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -139,7 +139,7 @@ func BenchmarkAggWide(b *testing.B) {
 
 			for b.Loop() {
 				for _, v := range vals {
-					if err := n.Next(node.NewDescLID(v)); err != nil {
+					if err := n.Next(node.NewAscLID(v)); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -202,14 +202,14 @@ func TestTwoSourceAggregator(t *testing.T) {
 	dp := &MockTokenIndex{}
 	field := &MockNode{
 		Pairs: []IDSourcePair{
-			{LID: node.NewDescLID(1), Source: 0},
-			{LID: node.NewDescLID(2), Source: 1},
+			{LID: node.NewAscLID(1), Source: 0},
+			{LID: node.NewAscLID(2), Source: 1},
 		},
 	}
 	groupBy := &MockNode{
 		Pairs: []IDSourcePair{
-			{LID: node.NewDescLID(1), Source: 0},
-			{LID: node.NewDescLID(2), Source: 1},
+			{LID: node.NewAscLID(1), Source: 0},
+			{LID: node.NewAscLID(2), Source: 1},
 		},
 	}
 
@@ -223,8 +223,8 @@ func TestTwoSourceAggregator(t *testing.T) {
 	)
 
 	// Call Next for two data points.
-	r.NoError(aggregator.Next(node.NewDescLID(1)))
-	r.NoError(aggregator.Next(node.NewDescLID(2)))
+	r.NoError(aggregator.Next(node.NewAscLID(1)))
+	r.NoError(aggregator.Next(node.NewAscLID(2)))
 
 	// Verify countBySource map.
 	expectedCountBySource := map[twoSources]int64{
@@ -264,14 +264,14 @@ func TestSingleTreeCountAggregator(t *testing.T) {
 	dp := &MockTokenIndex{}
 	field := &MockNode{
 		Pairs: []IDSourcePair{
-			{LID: node.NewDescLID(1), Source: 0},
+			{LID: node.NewAscLID(1), Source: 0},
 		},
 	}
 
 	iter := NewSourcedNodeIterator(field, dp, []uint32{0}, "field", iteratorLimit{limit: 0, err: consts.ErrTooManyGroupTokens})
 	aggregator := NewSingleSourceCountAggregator(iter, provideExtractTimeFunc(nil, nil, 0))
 
-	r.NoError(aggregator.Next(node.NewDescLID(1)))
+	r.NoError(aggregator.Next(node.NewAscLID(1)))
 
 	result, err := aggregator.Aggregate()
 	if err != nil {
@@ -313,7 +313,7 @@ func TestAggregatorLimitExceeded(t *testing.T) {
 		var limitIteration int
 
 		for i, id := range searchDocs {
-			if err := agg.Next(node.NewDescLID(id)); err != nil {
+			if err := agg.Next(node.NewAscLID(id)); err != nil {
 				limitErr = err
 				limitIteration = i
 				break

--- a/frac/processor/batch_eval_tree.go
+++ b/frac/processor/batch_eval_tree.go
@@ -154,7 +154,7 @@ func buildBatchEvalTree(
 	root *parser.ASTNode,
 	minLID, maxLID uint32,
 	stats *searchStats,
-	desc bool,
+	asc bool,
 	newBatchLeaf func(parser.Token) (node.BatchedNode, error),
 ) (node.BatchedNode, error) {
 	if root == nil {
@@ -163,7 +163,7 @@ func buildBatchEvalTree(
 
 	children := make([]node.BatchedNode, 0, len(root.Children))
 	for _, child := range root.Children {
-		childNode, err := buildBatchEvalTree(child, minLID, maxLID, stats, desc, newBatchLeaf)
+		childNode, err := buildBatchEvalTree(child, minLID, maxLID, stats, asc, newBatchLeaf)
 		if err != nil {
 			return nil, err
 		}
@@ -179,11 +179,11 @@ func buildBatchEvalTree(
 		stats.NodesTotal++
 		switch token.Operator {
 		case parser.LogicalAnd:
-			return node.NewAndBatched(children[0], children[1], desc), nil
+			return node.NewAndBatched(children[0], children[1], asc), nil
 		case parser.LogicalOr:
-			return node.NewOrBatched(children[0], children[1], desc), nil
+			return node.NewOrBatched(children[0], children[1], asc), nil
 		case parser.LogicalNAnd:
-			return node.NewNAndBatched(children[0], children[1], desc), nil
+			return node.NewNAndBatched(children[0], children[1], asc), nil
 		default:
 			return nil, fmt.Errorf("unsupported logical operator for batched eval: %v", token.Operator)
 		}

--- a/frac/processor/eval_test.go
+++ b/frac/processor/eval_test.go
@@ -46,7 +46,7 @@ func (p *staticProvider) newStatic(literal *parser.Literal) (node.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return node.NewStatic(data, false), nil
+	return node.NewStatic(data, true), nil
 }
 
 func readAllInto(n node.Node, ids []uint32) []uint32 {

--- a/frac/processor/eval_tree.go
+++ b/frac/processor/eval_tree.go
@@ -48,11 +48,11 @@ func buildEvalTree(root *parser.ASTNode, minVal, maxVal uint32, stats *searchSta
 			var minLID node.LID
 			var maxLID node.LID
 			if reverse {
-				minLID = node.NewAscLID(maxVal)
-				maxLID = node.NewAscLID(minVal)
+				minLID = node.NewDescLID(maxVal)
+				maxLID = node.NewDescLID(minVal)
 			} else {
-				minLID = node.NewDescLID(minVal)
-				maxLID = node.NewDescLID(maxVal)
+				minLID = node.NewAscLID(minVal)
+				maxLID = node.NewAscLID(maxVal)
 			}
 			return node.NewNot(children[0], minLID, maxLID), nil
 		}

--- a/frac/processor/search_test.go
+++ b/frac/processor/search_test.go
@@ -46,7 +46,7 @@ func TestIterateEvalTreeDuplicateIDsAtBatchBoundary(t *testing.T) {
 	}}
 
 	// Single batch with 6 LIDs, longer than the limit.
-	evalTree := node.NewStaticBatched([]uint32{1, 2, 3, 4, 5, 6}, seq.DocsOrderDesc.IsReverse())
+	evalTree := node.NewStaticBatched([]uint32{1, 2, 3, 4, 5, 6}, seq.DocsOrderDesc.IsDesc())
 
 	params := SearchParams{
 		Limit: 3,

--- a/frac/sealed/lids/iterator_asc.go
+++ b/frac/sealed/lids/iterator_asc.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ozontech/seq-db/node"
 )
 
-// IteratorAsc iterates LIDs in ascending order (low to high).
+// IteratorAsc iterates LIDs in ascending order. Used for time order desc (default order).
 type IteratorAsc struct {
 	Cursor
 	it node.Iter
@@ -39,13 +39,13 @@ func (it *IteratorAsc) narrowLIDsRange(tryNextBlock bool) bool {
 	}
 
 	first := it.batch.Min()
-	if it.maxLID < first { // fast path: out-of-bounds 1
+	if first > it.maxLID { // fast path: out-of-bounds 1
 		it.batch = node.EmptyBatch() // stop reading blocks
 		return false
 	}
 
 	last := it.batch.Max()
-	if it.minLID > last { // fast path: out-of-bounds 2; allowed to continue reading blocks
+	if last < it.minLID { // fast path: out-of-bounds 2; allowed to continue reading blocks
 		it.batch = node.EmptyBatch()
 		return tryNextBlock
 	}

--- a/frac/sealed/lids/iterator_asc.go
+++ b/frac/sealed/lids/iterator_asc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ozontech/seq-db/node"
 )
 
+// IteratorAsc iterates LIDs in ascending order (low to high).
 type IteratorAsc struct {
 	Cursor
 	it node.Iter
@@ -23,7 +24,7 @@ func NewIteratorAsc(
 	it := &IteratorAsc{
 		Cursor: NewLIDsCursor(table, loader, startIndex, tid, counter, minLID, maxLID),
 	}
-	it.it = it.batch.ReverseIter()
+	it.it = it.batch.Iter()
 	return it
 }
 
@@ -38,18 +39,18 @@ func (it *IteratorAsc) narrowLIDsRange(tryNextBlock bool) bool {
 	}
 
 	first := it.batch.Min()
-	if it.maxLID < first { // fast path: out-of-bounds 1; allowed to continue reading blocks
-		it.batch = node.EmptyBatch()
-		return tryNextBlock
-	}
-
-	last := it.batch.Max()
-	if it.minLID > last { // fast path: out-of-bounds 2
+	if it.maxLID < first { // fast path: out-of-bounds 1
 		it.batch = node.EmptyBatch() // stop reading blocks
 		return false
 	}
 
-	lastBlock := it.minLID > first
+	last := it.batch.Max()
+	if it.minLID > last { // fast path: out-of-bounds 2; allowed to continue reading blocks
+		it.batch = node.EmptyBatch()
+		return tryNextBlock
+	}
+
+	lastBlock := it.maxLID < last
 	it.batch = it.batch.Narrow(it.minLID, it.maxLID)
 	if lastBlock {
 		tryNextBlock = false
@@ -69,18 +70,18 @@ func (it *IteratorAsc) loadNextLIDsBlock() {
 	}
 
 	it.batch = block.GetLIDs(it.table.GetChunkIndex(it.blockIndex, it.tid))
-	tryNextBlock := it.table.HasTIDInPrevBlock(it.blockIndex, it.tid)
-	it.tryNextBlock = it.narrowLIDsRange(tryNextBlock)
-	it.it = it.batch.ReverseIter()
 	it.counter.AddLIDsCount(it.batch.Len())
-	it.blockIndex--
+	tryNextBlock := it.table.HasTIDInNextBlock(it.blockIndex, it.tid)
+	it.tryNextBlock = it.narrowLIDsRange(tryNextBlock)
+	it.it = it.batch.Iter()
+	it.blockIndex++
 }
 
 func (it *IteratorAsc) Next() node.LID {
 	for {
-		lid, ok := it.it.Next()
+		v, ok := it.it.Next()
 		if ok {
-			return node.NewAscLID(lid)
+			return node.NewAscLID(v)
 		}
 		if !it.tryNextBlock {
 			return node.NullLID()
@@ -89,18 +90,18 @@ func (it *IteratorAsc) Next() node.LID {
 	}
 }
 
-// NextGeq returns the next (in reverse iteration order) LID that is <= maxLID.
+// NextGeq finds next greater or equal
 func (it *IteratorAsc) NextGeq(nextID node.LID) node.LID {
 	for {
-		lid, ok := it.it.NextGeq(nextID.Unpack())
+		v, ok := it.it.NextGeq(nextID.Unpack())
 		if ok {
-			return node.NewAscLID(lid)
+			return node.NewAscLID(v)
 		}
 		if !it.tryNextBlock {
 			return node.NullLID()
 		}
 
-		it.blockIndex = it.table.SeekBlockLeq(it.blockIndex, it.tid, nextID.Unpack())
+		it.blockIndex = it.table.SeekBlockGeq(it.blockIndex, it.tid, nextID.Unpack())
 		it.loadNextLIDsBlock()
 	}
 }

--- a/frac/sealed/lids/iterator_batched_asc.go
+++ b/frac/sealed/lids/iterator_batched_asc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ozontech/seq-db/node"
 )
 
+// BatchedIteratorAsc iterates LID batches in ascending order (low to high).
 type BatchedIteratorAsc struct {
 	Cursor
 }
@@ -30,16 +31,16 @@ func (it *BatchedIteratorAsc) narrowLIDsRange(tryNextBlock bool) bool {
 	first := it.batch.Min()
 	if it.maxLID < first {
 		it.batch = node.EmptyBatch()
-		return tryNextBlock
+		return false
 	}
 
 	batchMax := it.batch.Max()
 	if it.minLID > batchMax {
 		it.batch = node.EmptyBatch()
-		return false
+		return tryNextBlock
 	}
 
-	lastBlock := it.minLID > first
+	lastBlock := it.maxLID < batchMax
 	it.batch = it.batch.Narrow(it.minLID, it.maxLID)
 	if lastBlock {
 		tryNextBlock = false
@@ -59,10 +60,10 @@ func (it *BatchedIteratorAsc) loadNextLIDsBlock() {
 	}
 
 	it.batch = block.GetLIDs(it.table.GetChunkIndex(it.blockIndex, it.tid))
-	it.tryNextBlock = it.table.HasTIDInPrevBlock(it.blockIndex, it.tid)
+	it.tryNextBlock = it.table.HasTIDInNextBlock(it.blockIndex, it.tid)
 	it.tryNextBlock = it.narrowLIDsRange(it.tryNextBlock)
 	it.counter.AddLIDsCount(it.batch.Len())
-	it.blockIndex--
+	it.blockIndex++
 }
 
 func (it *BatchedIteratorAsc) NextBatch() node.LIDBatch {
@@ -76,7 +77,7 @@ func (it *BatchedIteratorAsc) NextBatchGeq(nextID node.LID) node.LIDBatch {
 				return node.EmptyBatch()
 			}
 
-			it.blockIndex = it.table.SeekBlockLeq(it.blockIndex, it.tid, nextID.Unpack())
+			it.blockIndex = it.table.SeekBlockGeq(it.blockIndex, it.tid, nextID.Unpack())
 			it.loadNextLIDsBlock()
 		}
 
@@ -84,7 +85,7 @@ func (it *BatchedIteratorAsc) NextBatchGeq(nextID node.LID) node.LIDBatch {
 			continue
 		}
 
-		if nextID.Unpack() < it.batch.Min() {
+		if nextID.Unpack() > it.batch.Max() {
 			it.batch = node.EmptyBatch()
 			continue
 		}

--- a/frac/sealed/lids/iterator_batched_asc.go
+++ b/frac/sealed/lids/iterator_batched_asc.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ozontech/seq-db/node"
 )
 
-// BatchedIteratorAsc iterates LID batches in ascending order (low to high).
+// BatchedIteratorAsc iterates LID batches in ascending order. Used for time order desc (default order).
 type BatchedIteratorAsc struct {
 	Cursor
 }

--- a/frac/sealed/lids/iterator_batched_desc.go
+++ b/frac/sealed/lids/iterator_batched_desc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ozontech/seq-db/node"
 )
 
+// BatchedIteratorDesc iterates LID batches in descending order (high to low).
 type BatchedIteratorDesc struct {
 	Cursor
 }
@@ -30,16 +31,16 @@ func (it *BatchedIteratorDesc) narrowLIDsRange(tryNextBlock bool) bool {
 	first := it.batch.Min()
 	if it.maxLID < first {
 		it.batch = node.EmptyBatch()
-		return false
+		return tryNextBlock
 	}
 
 	batchMax := it.batch.Max()
 	if it.minLID > batchMax {
 		it.batch = node.EmptyBatch()
-		return tryNextBlock
+		return false
 	}
 
-	lastBlock := it.maxLID < batchMax
+	lastBlock := it.minLID > first
 	it.batch = it.batch.Narrow(it.minLID, it.maxLID)
 	if lastBlock {
 		tryNextBlock = false
@@ -59,10 +60,10 @@ func (it *BatchedIteratorDesc) loadNextLIDsBlock() {
 	}
 
 	it.batch = block.GetLIDs(it.table.GetChunkIndex(it.blockIndex, it.tid))
-	it.tryNextBlock = it.table.HasTIDInNextBlock(it.blockIndex, it.tid)
+	it.tryNextBlock = it.table.HasTIDInPrevBlock(it.blockIndex, it.tid)
 	it.tryNextBlock = it.narrowLIDsRange(it.tryNextBlock)
 	it.counter.AddLIDsCount(it.batch.Len())
-	it.blockIndex++
+	it.blockIndex--
 }
 
 func (it *BatchedIteratorDesc) NextBatch() node.LIDBatch {
@@ -76,7 +77,7 @@ func (it *BatchedIteratorDesc) NextBatchGeq(nextID node.LID) node.LIDBatch {
 				return node.EmptyBatch()
 			}
 
-			it.blockIndex = it.table.SeekBlockGeq(it.blockIndex, it.tid, nextID.Unpack())
+			it.blockIndex = it.table.SeekBlockLeq(it.blockIndex, it.tid, nextID.Unpack())
 			it.loadNextLIDsBlock()
 		}
 
@@ -84,7 +85,7 @@ func (it *BatchedIteratorDesc) NextBatchGeq(nextID node.LID) node.LIDBatch {
 			continue
 		}
 
-		if nextID.Unpack() > it.batch.Max() {
+		if nextID.Unpack() < it.batch.Min() {
 			it.batch = node.EmptyBatch()
 			continue
 		}

--- a/frac/sealed/lids/iterator_batched_desc.go
+++ b/frac/sealed/lids/iterator_batched_desc.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ozontech/seq-db/node"
 )
 
-// BatchedIteratorDesc iterates LID batches in descending order (high to low).
+// BatchedIteratorDesc iterates LID batches in descending order. Used for time order asc (reverse order).
 type BatchedIteratorDesc struct {
 	Cursor
 }

--- a/frac/sealed/lids/iterator_desc.go
+++ b/frac/sealed/lids/iterator_desc.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ozontech/seq-db/node"
 )
 
-// IteratorDesc iterates LIDs in descending order (high to low).
+// IteratorDesc iterates LIDs in descending order. Used for time order asc (reverse order).
 type IteratorDesc struct {
 	Cursor
 	it node.Iter

--- a/frac/sealed/lids/iterator_desc.go
+++ b/frac/sealed/lids/iterator_desc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ozontech/seq-db/node"
 )
 
+// IteratorDesc iterates LIDs in descending order (high to low).
 type IteratorDesc struct {
 	Cursor
 	it node.Iter
@@ -23,7 +24,7 @@ func NewIteratorDesc(
 	it := &IteratorDesc{
 		Cursor: NewLIDsCursor(table, loader, startIndex, tid, counter, minLID, maxLID),
 	}
-	it.it = it.batch.Iter()
+	it.it = it.batch.ReverseIter()
 	return it
 }
 
@@ -38,18 +39,18 @@ func (it *IteratorDesc) narrowLIDsRange(tryNextBlock bool) bool {
 	}
 
 	first := it.batch.Min()
-	if it.maxLID < first { // fast path: out-of-bounds 1
-		it.batch = node.EmptyBatch() // stop reading blocks
-		return false
-	}
-
-	last := it.batch.Max()
-	if it.minLID > last { // fast path: out-of-bounds 2; allowed to continue reading blocks
+	if it.maxLID < first { // fast path: out-of-bounds 1; allowed to continue reading blocks
 		it.batch = node.EmptyBatch()
 		return tryNextBlock
 	}
 
-	lastBlock := it.maxLID < last
+	last := it.batch.Max()
+	if it.minLID > last { // fast path: out-of-bounds 2
+		it.batch = node.EmptyBatch() // stop reading blocks
+		return false
+	}
+
+	lastBlock := it.minLID > first
 	it.batch = it.batch.Narrow(it.minLID, it.maxLID)
 	if lastBlock {
 		tryNextBlock = false
@@ -69,18 +70,18 @@ func (it *IteratorDesc) loadNextLIDsBlock() {
 	}
 
 	it.batch = block.GetLIDs(it.table.GetChunkIndex(it.blockIndex, it.tid))
-	it.counter.AddLIDsCount(it.batch.Len())
-	tryNextBlock := it.table.HasTIDInNextBlock(it.blockIndex, it.tid)
+	tryNextBlock := it.table.HasTIDInPrevBlock(it.blockIndex, it.tid)
 	it.tryNextBlock = it.narrowLIDsRange(tryNextBlock)
-	it.it = it.batch.Iter()
-	it.blockIndex++
+	it.it = it.batch.ReverseIter()
+	it.counter.AddLIDsCount(it.batch.Len())
+	it.blockIndex--
 }
 
 func (it *IteratorDesc) Next() node.LID {
 	for {
-		v, ok := it.it.Next()
+		lid, ok := it.it.Next()
 		if ok {
-			return node.NewDescLID(v)
+			return node.NewDescLID(lid)
 		}
 		if !it.tryNextBlock {
 			return node.NullLID()
@@ -89,18 +90,18 @@ func (it *IteratorDesc) Next() node.LID {
 	}
 }
 
-// NextGeq finds next greater or equal
+// NextGeq returns the next (in descending iteration order) LID that is <= maxLID.
 func (it *IteratorDesc) NextGeq(nextID node.LID) node.LID {
 	for {
-		v, ok := it.it.NextGeq(nextID.Unpack())
+		lid, ok := it.it.NextGeq(nextID.Unpack())
 		if ok {
-			return node.NewDescLID(v)
+			return node.NewDescLID(lid)
 		}
 		if !it.tryNextBlock {
 			return node.NullLID()
 		}
 
-		it.blockIndex = it.table.SeekBlockGeq(it.blockIndex, it.tid, nextID.Unpack())
+		it.blockIndex = it.table.SeekBlockLeq(it.blockIndex, it.tid, nextID.Unpack())
 		it.loadNextLIDsBlock()
 	}
 }

--- a/frac/sealed_index.go
+++ b/frac/sealed_index.go
@@ -305,12 +305,12 @@ func (ti *sealedTokenIndex) GetLIDsFromTIDs(tids []uint32, stats lids.Counter, m
 	if order.IsReverse() {
 		getBlockIndex = func(tid uint32) uint32 { return ti.lidsTable.GetLastBlockIndexForTID(tid) }
 		getLIDsIterator = func(startIndex uint32, tid uint32) node.Node {
-			return lids.NewIteratorAsc(ti.lidsTable, ti.lidsLoader, startIndex, tid, stats, minLID, maxLID)
+			return lids.NewIteratorDesc(ti.lidsTable, ti.lidsLoader, startIndex, tid, stats, minLID, maxLID)
 		}
 	} else {
 		getBlockIndex = func(tid uint32) uint32 { return ti.lidsTable.GetFirstBlockIndexForTID(tid) }
 		getLIDsIterator = func(startIndex uint32, tid uint32) node.Node {
-			return lids.NewIteratorDesc(ti.lidsTable, ti.lidsLoader, startIndex, tid, stats, minLID, maxLID)
+			return lids.NewIteratorAsc(ti.lidsTable, ti.lidsLoader, startIndex, tid, stats, minLID, maxLID)
 		}
 	}
 
@@ -336,12 +336,12 @@ func (ti *sealedTokenIndex) GetBatchedLIDsFromTIDs(tids []uint32, stats lids.Cou
 	if order.IsReverse() {
 		getBlockIndex = func(tid uint32) uint32 { return ti.lidsTable.GetLastBlockIndexForTID(tid) }
 		getBatchedLIDsIterator = func(startIndex uint32, tid uint32) node.BatchedNode {
-			return lids.NewBatchedIteratorAsc(lids.NewIteratorAsc(ti.lidsTable, ti.lidsLoader, startIndex, tid, stats, minLID, maxLID))
+			return lids.NewBatchedIteratorDesc(lids.NewIteratorDesc(ti.lidsTable, ti.lidsLoader, startIndex, tid, stats, minLID, maxLID))
 		}
 	} else {
 		getBlockIndex = func(tid uint32) uint32 { return ti.lidsTable.GetFirstBlockIndexForTID(tid) }
 		getBatchedLIDsIterator = func(startIndex uint32, tid uint32) node.BatchedNode {
-			return lids.NewBatchedIteratorDesc(lids.NewIteratorDesc(ti.lidsTable, ti.lidsLoader, startIndex, tid, stats, minLID, maxLID))
+			return lids.NewBatchedIteratorAsc(lids.NewIteratorAsc(ti.lidsTable, ti.lidsLoader, startIndex, tid, stats, minLID, maxLID))
 		}
 	}
 

--- a/fracmanager/fracmanager_test.go
+++ b/fracmanager/fracmanager_test.go
@@ -16,7 +16,7 @@ import (
 type testSkipMaskProvider struct{}
 
 func (testSkipMaskProvider) GetIDsIteratorByFrac(fracName string, minLID, maxLID uint32, reverse bool) (node.Node, bool, func() error, error) {
-	return node.NewStatic([]uint32{}, reverse), false, func() error { return nil }, nil
+	return node.NewStatic([]uint32{}, !reverse), false, func() error { return nil }, nil
 }
 func (testSkipMaskProvider) GetIDsBitmapByFrac(fracName string, minLID, maxLID uint32) (*roaring.Bitmap, error) {
 	return nil, nil

--- a/node/batch.go
+++ b/node/batch.go
@@ -16,7 +16,7 @@ type LIDBatch interface {
 	Min() uint32
 	// Max returns max (last) value. Panics if batch is empty.
 	Max() uint32
-	ManyIter(desc bool) ManyIter
+	ManyIter(asc bool) ManyIter
 	// Iter iterates lids in ascending way.
 	Iter() Iter
 	// ReverseIter iterates lids in descending way.
@@ -115,9 +115,9 @@ func (b *sliceBatch) ReverseIter() Iter {
 	return &sliceReverseIter{lids: b.lids, idx: len(b.lids) - 1}
 }
 
-func (b *sliceBatch) ManyIter(desc bool) ManyIter {
-	it := &sliceManyIter{lids: b.lids, desc: desc}
-	if !desc {
+func (b *sliceBatch) ManyIter(asc bool) ManyIter {
+	it := &sliceManyIter{lids: b.lids, asc: asc}
+	if !asc {
 		it.pos = len(b.lids) - 1
 	}
 	return it
@@ -126,17 +126,17 @@ func (b *sliceBatch) ManyIter(desc bool) ManyIter {
 type sliceManyIter struct {
 	lids []uint32
 	pos  int
-	desc bool
+	asc  bool
 }
 
 func (it *sliceManyIter) CopyLIDs(dst []LID, tmp []uint32) int {
 	if len(dst) == 0 || len(tmp) == 0 {
 		return 0
 	}
-	if it.desc {
+	if it.asc {
 		n := min(len(dst), len(tmp), len(it.lids)-it.pos)
 		for i := 0; i < n; i++ {
-			dst[i] = NewDescLID(it.lids[it.pos+i])
+			dst[i] = NewAscLID(it.lids[it.pos+i])
 		}
 		it.pos += n
 		return n
@@ -146,7 +146,7 @@ func (it *sliceManyIter) CopyLIDs(dst []LID, tmp []uint32) int {
 	}
 	n := min(len(dst), len(tmp), it.pos+1)
 	for i := 0; i < n; i++ {
-		dst[i] = NewAscLID(it.lids[it.pos-i])
+		dst[i] = NewDescLID(it.lids[it.pos-i])
 	}
 	it.pos -= n
 	return n
@@ -255,8 +255,8 @@ func (b *bitmapBatch) ReverseIter() Iter {
 	return newBitmapReverseIter(b.bm)
 }
 
-func (b *bitmapBatch) ManyIter(desc bool) ManyIter {
-	if desc {
+func (b *bitmapBatch) ManyIter(asc bool) ManyIter {
+	if asc {
 		return &bitmapManyIterAsc{it: b.bm.ManyIterator()}
 	}
 	return &bitmapManyIterDesc{it: b.bm.ReverseIterator()}
@@ -272,7 +272,7 @@ func (it *bitmapManyIterAsc) CopyLIDs(dst []LID, tmp []uint32) int {
 	}
 	n := it.it.NextMany(tmp[:min(len(dst), len(tmp))])
 	for i := 0; i < n; i++ {
-		dst[i] = NewDescLID(tmp[i])
+		dst[i] = NewAscLID(tmp[i])
 	}
 	return n
 }
@@ -288,7 +288,7 @@ func (it *bitmapManyIterDesc) CopyLIDs(dst []LID, tmp []uint32) int {
 	n := 0
 	limit := min(len(dst), len(tmp))
 	for n < limit && it.it.HasNext() {
-		dst[n] = NewAscLID(it.it.Next())
+		dst[n] = NewDescLID(it.it.Next())
 		n++
 	}
 	return n

--- a/node/batch_ops.go
+++ b/node/batch_ops.go
@@ -6,9 +6,9 @@ import (
 	"github.com/RoaringBitmap/roaring/v2"
 )
 
-// And intersects two batches in the given document order and returns result and unprocessed parts (either left or right
+// And intersects two batches in the given LID order and returns result and unprocessed parts (either left or right
 // will be empty). For AND operation left and right residuals are equal to provided left or right batch, it's safe.
-func And(left, right LIDBatch, desc bool) (result, leftResidual, rightResidual LIDBatch) {
+func And(left, right LIDBatch, asc bool) (result, leftResidual, rightResidual LIDBatch) {
 	empty := EmptyBatch()
 	if left.IsEmpty() || right.IsEmpty() {
 		return empty, empty, empty
@@ -23,7 +23,7 @@ func And(left, right LIDBatch, desc bool) (result, leftResidual, rightResidual L
 
 	// If left or right are slice batches, we must return leftBm and rightBm (bitmap copies), since
 	// left or right might be intersected with another batch again soon.
-	if desc {
+	if asc {
 		if leftBm.max > rightBm.max {
 			return result, leftBm, empty
 		}
@@ -43,7 +43,7 @@ func And(left, right LIDBatch, desc bool) (result, leftResidual, rightResidual L
 }
 
 // AndNot finds "AND NOT" result for two batches and returns result and unprocessed parts.
-func AndNot(reg, neg LIDBatch, desc bool) (result, regResidual, negResidual LIDBatch) {
+func AndNot(reg, neg LIDBatch, asc bool) (result, regResidual, negResidual LIDBatch) {
 	empty := EmptyBatch()
 	if reg.IsEmpty() {
 		return empty, empty, neg
@@ -58,12 +58,12 @@ func AndNot(reg, neg LIDBatch, desc bool) (result, regResidual, negResidual LIDB
 	resultBm := regBm.bm.Clone()
 	resultBm.AndNot(negBm.bm)
 
-	return truncateBatches(resultBm, regBm, negBm, desc)
+	return truncateBatches(resultBm, regBm, negBm, asc)
 }
 
-// Or unions two batches in the given document order and returns result and unprocessed parts (either left or right
+// Or unions two batches in the given LID order and returns result and unprocessed parts (either left or right
 // will be empty).
-func Or(left, right LIDBatch, desc bool) (result, leftResidual, rightResidual LIDBatch) {
+func Or(left, right LIDBatch, asc bool) (result, leftResidual, rightResidual LIDBatch) {
 	empty := EmptyBatch()
 	if left.IsEmpty() {
 		return right, empty, empty
@@ -78,12 +78,12 @@ func Or(left, right LIDBatch, desc bool) (result, leftResidual, rightResidual LI
 	resultBm := leftBm.bm.Clone()
 	resultBm.Or(rightBm.bm)
 
-	return truncateBatches(resultBm, leftBm, rightBm, desc)
+	return truncateBatches(resultBm, leftBm, rightBm, asc)
 }
 
-// OrMulti unions multiple batches in the given document order and returns
+// OrMulti unions multiple batches in the given LID order and returns
 // result and unprocessed parts for each input batch.
-func OrMulti(batches []LIDBatch, desc bool) (result LIDBatch, residuals []LIDBatch) {
+func OrMulti(batches []LIDBatch, asc bool) (result LIDBatch, residuals []LIDBatch) {
 	residuals = make([]LIDBatch, len(batches))
 	bmBatches := make([]*bitmapBatch, len(batches))
 	nonEmptyBmBatches := make([]*bitmapBatch, 0, len(batches))
@@ -111,7 +111,7 @@ func OrMulti(batches []LIDBatch, desc bool) (result LIDBatch, residuals []LIDBat
 
 	resultBm := roaring.FastOr(bitmaps...)
 
-	if desc {
+	if asc {
 		minMax := nonEmptyBmBatches[0].max
 		for i := 1; i < len(nonEmptyBmBatches); i++ {
 			if nonEmptyBmBatches[i].max < minMax {
@@ -148,8 +148,8 @@ func OrMulti(batches []LIDBatch, desc bool) (result LIDBatch, residuals []LIDBat
 	return NewBitmapBatch(resultBm), residuals
 }
 
-func truncateBatches(result *roaring.Bitmap, left, right *bitmapBatch, desc bool) (LIDBatch, LIDBatch, LIDBatch) {
-	if desc {
+func truncateBatches(result *roaring.Bitmap, left, right *bitmapBatch, asc bool) (LIDBatch, LIDBatch, LIDBatch) {
+	if asc {
 		if left.max > right.max {
 			leftRes := left.Narrow(right.max+1, math.MaxUint32)
 			result.RemoveRange(uint64(right.max)+1, math.MaxUint64)

--- a/node/batch_ops_test.go
+++ b/node/batch_ops_test.go
@@ -11,7 +11,7 @@ type batchCase struct {
 	name         string
 	left         []uint32
 	right        []uint32
-	desc         bool
+	asc          bool
 	wantResult   []uint32
 	wantLeftRes  []uint32
 	wantRightRes []uint32
@@ -30,55 +30,55 @@ var opsBatchFactories = []struct {
 func TestLIDBatch_And(t *testing.T) {
 	testCases := []batchCase{
 		{
-			name:         "desc overlap left has upper tail",
+			name:         "asc overlap left has upper tail",
 			left:         []uint32{1, 2, 3, 7, 8, 11, 15},
 			right:        []uint32{1, 3, 7, 10},
-			desc:         true,
+			asc:          true,
 			wantResult:   []uint32{1, 3, 7},
 			wantLeftRes:  []uint32{1, 2, 3, 7, 8, 11, 15},
 			wantRightRes: nil,
 		},
 		{
-			name:         "desc overlap right has upper tail",
+			name:         "asc overlap right has upper tail",
 			left:         []uint32{1, 3, 7, 10},
 			right:        []uint32{1, 2, 3, 7, 8, 11, 15},
-			desc:         true,
+			asc:          true,
 			wantResult:   []uint32{1, 3, 7},
 			wantLeftRes:  nil,
 			wantRightRes: []uint32{1, 2, 3, 7, 8, 11, 15},
 		},
 		{
-			name:         "desc disjoint lower vs upper",
+			name:         "asc disjoint lower vs upper",
 			left:         []uint32{1, 2, 3},
 			right:        []uint32{10, 11},
-			desc:         true,
+			asc:          true,
 			wantResult:   nil,
 			wantLeftRes:  nil,
 			wantRightRes: []uint32{10, 11},
 		},
 		{
-			name:         "asc overlap left has lower tail",
+			name:         "desc overlap left has lower tail",
 			left:         []uint32{1, 2, 3, 7, 8, 11, 15},
 			right:        []uint32{1, 3, 7, 10},
-			desc:         false,
+			asc:          false,
 			wantResult:   []uint32{1, 3, 7},
 			wantLeftRes:  nil,
 			wantRightRes: nil,
 		},
 		{
-			name:         "asc overlap right has lower tail",
+			name:         "desc overlap right has lower tail",
 			left:         []uint32{1, 3, 7, 10},
 			right:        []uint32{1, 2, 3, 7, 8, 11, 15},
-			desc:         false,
+			asc:          false,
 			wantResult:   []uint32{1, 3, 7},
 			wantLeftRes:  nil,
 			wantRightRes: nil,
 		},
 		{
-			name:         "asc disjoint lower vs upper",
+			name:         "desc disjoint lower vs upper",
 			left:         []uint32{1, 2, 3},
 			right:        []uint32{10, 11},
-			desc:         false,
+			asc:          false,
 			wantResult:   nil,
 			wantLeftRes:  []uint32{1, 2, 3},
 			wantRightRes: nil,
@@ -87,7 +87,7 @@ func TestLIDBatch_And(t *testing.T) {
 			name:         "identical inputs have no residuals",
 			left:         []uint32{2, 4, 9},
 			right:        []uint32{2, 4, 9},
-			desc:         true,
+			asc:          true,
 			wantResult:   []uint32{2, 4, 9},
 			wantLeftRes:  nil,
 			wantRightRes: nil,
@@ -96,7 +96,7 @@ func TestLIDBatch_And(t *testing.T) {
 			name:         "empty left",
 			left:         nil,
 			right:        []uint32{5, 6},
-			desc:         true,
+			asc:          true,
 			wantResult:   nil,
 			wantLeftRes:  nil,
 			wantRightRes: nil,
@@ -110,7 +110,7 @@ func TestLIDBatch_And(t *testing.T) {
 					left := impl.fn(tc.left)
 					right := impl.fn(tc.right)
 
-					result, leftRes, rightRes := And(left, right, tc.desc)
+					result, leftRes, rightRes := And(left, right, tc.asc)
 
 					assertSameSet(t, tc.wantResult, toSlice(result))
 					assertSameSet(t, tc.wantLeftRes, toSlice(leftRes))
@@ -124,55 +124,55 @@ func TestLIDBatch_And(t *testing.T) {
 func TestLIDBatch_Or(t *testing.T) {
 	testCases := []batchCase{
 		{
-			name:         "desc overlap left has upper tail",
+			name:         "asc overlap left has upper tail",
 			left:         []uint32{1, 2, 3, 7, 8, 11, 15},
 			right:        []uint32{1, 3, 7, 10},
-			desc:         true,
+			asc:          true,
 			wantResult:   []uint32{1, 2, 3, 7, 8, 10},
 			wantLeftRes:  []uint32{11, 15},
 			wantRightRes: nil,
 		},
 		{
-			name:         "desc overlap right has upper tail",
+			name:         "asc overlap right has upper tail",
 			left:         []uint32{1, 3, 7, 10},
 			right:        []uint32{1, 2, 3, 7, 8, 11, 15},
-			desc:         true,
+			asc:          true,
 			wantResult:   []uint32{1, 2, 3, 7, 8, 10},
 			wantLeftRes:  nil,
 			wantRightRes: []uint32{11, 15},
 		},
 		{
-			name:         "desc disjoint lower vs upper",
+			name:         "asc disjoint lower vs upper",
 			left:         []uint32{1, 2, 3},
 			right:        []uint32{10, 11},
-			desc:         true,
+			asc:          true,
 			wantResult:   []uint32{1, 2, 3},
 			wantLeftRes:  nil,
 			wantRightRes: []uint32{10, 11},
 		},
 		{
-			name:         "asc overlap left has lower tail",
+			name:         "desc overlap left has lower tail",
 			left:         []uint32{1, 2, 3, 7, 8, 11, 15},
 			right:        []uint32{1, 3, 7, 10},
-			desc:         false,
+			asc:          false,
 			wantResult:   []uint32{1, 2, 3, 7, 8, 10, 11, 15},
 			wantLeftRes:  nil,
 			wantRightRes: nil,
 		},
 		{
-			name:         "asc overlap right has lower tail",
+			name:         "desc overlap right has lower tail",
 			left:         []uint32{1, 3, 7, 10},
 			right:        []uint32{1, 2, 3, 7, 8, 11, 15},
-			desc:         false,
+			asc:          false,
 			wantResult:   []uint32{1, 2, 3, 7, 8, 10, 11, 15},
 			wantLeftRes:  nil,
 			wantRightRes: nil,
 		},
 		{
-			name:         "asc disjoint lower vs upper",
+			name:         "desc disjoint lower vs upper",
 			left:         []uint32{1, 2, 3},
 			right:        []uint32{10, 11},
-			desc:         false,
+			asc:          false,
 			wantResult:   []uint32{10, 11},
 			wantLeftRes:  []uint32{1, 2, 3},
 			wantRightRes: nil,
@@ -181,7 +181,7 @@ func TestLIDBatch_Or(t *testing.T) {
 			name:         "empty left",
 			left:         nil,
 			right:        []uint32{5, 6},
-			desc:         false,
+			asc:          false,
 			wantResult:   []uint32{5, 6},
 			wantLeftRes:  nil,
 			wantRightRes: nil,
@@ -195,7 +195,7 @@ func TestLIDBatch_Or(t *testing.T) {
 					left := impl.fn(tc.left)
 					right := impl.fn(tc.right)
 
-					result, leftRes, rightRes := Or(left, right, tc.desc)
+					result, leftRes, rightRes := Or(left, right, tc.asc)
 
 					assertSameSet(t, tc.wantResult, toSlice(result))
 					assertSameSet(t, tc.wantLeftRes, toSlice(leftRes))
@@ -209,55 +209,55 @@ func TestLIDBatch_Or(t *testing.T) {
 func TestLIDBatch_AndNot(t *testing.T) {
 	testCases := []batchCase{
 		{
-			name:         "desc overlap reg has upper tail",
+			name:         "asc overlap reg has upper tail",
 			left:         []uint32{1, 2, 3, 7, 8, 11, 15},
 			right:        []uint32{1, 3, 7, 10},
-			desc:         true,
+			asc:          true,
 			wantResult:   []uint32{2, 8},
 			wantLeftRes:  []uint32{11, 15},
 			wantRightRes: nil,
 		},
 		{
-			name:         "desc overlap neg has upper tail",
+			name:         "asc overlap neg has upper tail",
 			left:         []uint32{1, 3, 7, 10},
 			right:        []uint32{1, 2, 3, 7, 8, 11, 15},
-			desc:         true,
+			asc:          true,
 			wantResult:   []uint32{10},
 			wantLeftRes:  nil,
 			wantRightRes: []uint32{11, 15},
 		},
 		{
-			name:         "desc disjoint lower reg vs upper neg",
+			name:         "asc disjoint lower reg vs upper neg",
 			left:         []uint32{1, 2, 3},
 			right:        []uint32{10, 11},
-			desc:         true,
+			asc:          true,
 			wantResult:   []uint32{1, 2, 3},
 			wantLeftRes:  nil,
 			wantRightRes: []uint32{10, 11},
 		},
 		{
-			name:         "asc overlap reg has lower tail",
+			name:         "desc overlap reg has lower tail",
 			left:         []uint32{1, 2, 3, 7, 8, 11, 15},
 			right:        []uint32{1, 3, 7, 10},
-			desc:         false,
+			asc:          false,
 			wantResult:   []uint32{2, 8, 11, 15},
 			wantLeftRes:  nil,
 			wantRightRes: nil,
 		},
 		{
-			name:         "asc overlap neg has lower tail",
+			name:         "desc overlap neg has lower tail",
 			left:         []uint32{1, 3, 7, 10},
 			right:        []uint32{1, 2, 3, 7, 8, 11, 15},
-			desc:         false,
+			asc:          false,
 			wantResult:   []uint32{10},
 			wantLeftRes:  nil,
 			wantRightRes: nil,
 		},
 		{
-			name:         "asc disjoint lower reg vs upper neg",
+			name:         "desc disjoint lower reg vs upper neg",
 			left:         []uint32{1, 2, 3},
 			right:        []uint32{10, 11},
-			desc:         false,
+			asc:          false,
 			wantResult:   nil,
 			wantLeftRes:  []uint32{1, 2, 3},
 			wantRightRes: nil,
@@ -266,7 +266,7 @@ func TestLIDBatch_AndNot(t *testing.T) {
 			name:         "empty reg",
 			left:         nil,
 			right:        []uint32{5, 6},
-			desc:         false,
+			asc:          false,
 			wantResult:   nil,
 			wantLeftRes:  nil,
 			wantRightRes: []uint32{5, 6},
@@ -275,7 +275,7 @@ func TestLIDBatch_AndNot(t *testing.T) {
 			name:         "empty neg",
 			left:         []uint32{5, 6},
 			right:        nil,
-			desc:         false,
+			asc:          false,
 			wantResult:   []uint32{5, 6},
 			wantLeftRes:  nil,
 			wantRightRes: nil,
@@ -289,7 +289,7 @@ func TestLIDBatch_AndNot(t *testing.T) {
 					reg := impl.fn(tc.left)
 					neg := impl.fn(tc.right)
 
-					result, regRes, negRes := AndNot(reg, neg, tc.desc)
+					result, regRes, negRes := AndNot(reg, neg, tc.asc)
 
 					assertSameSet(t, tc.wantResult, toSlice(result))
 					assertSameSet(t, tc.wantLeftRes, toSlice(regRes))
@@ -325,7 +325,7 @@ func TestLIDBatch_OrMixedTypes(t *testing.T) {
 func TestLIDBatch_OrMulti(t *testing.T) {
 	type orMultiCase struct {
 		name          string
-		desc          bool
+		asc           bool
 		inputs        [][]uint32
 		wantResult    []uint32
 		wantResiduals [][]uint32
@@ -333,8 +333,8 @@ func TestLIDBatch_OrMulti(t *testing.T) {
 
 	testCases := []orMultiCase{
 		{
-			name:       "desc overlap with one residual",
-			desc:       true,
+			name:       "asc overlap with one residual",
+			asc:        true,
 			inputs:     [][]uint32{{1, 2, 3, 7, 8, 11, 15}, {1, 3, 7, 10}, {2, 3, 5, 8, 10}},
 			wantResult: []uint32{1, 2, 3, 5, 7, 8, 10},
 			wantResiduals: [][]uint32{
@@ -344,8 +344,8 @@ func TestLIDBatch_OrMulti(t *testing.T) {
 			},
 		},
 		{
-			name:       "asc overlap with one residual",
-			desc:       false,
+			name:       "desc overlap with one residual",
+			asc:        false,
 			inputs:     [][]uint32{{1, 2, 3, 7, 8, 11, 15}, {1, 3, 7, 10}, {2, 3, 5, 8, 10}},
 			wantResult: []uint32{2, 3, 5, 7, 8, 10, 11, 15},
 			wantResiduals: [][]uint32{
@@ -356,7 +356,7 @@ func TestLIDBatch_OrMulti(t *testing.T) {
 		},
 		{
 			name:       "single non-empty behaves as pass-through",
-			desc:       true,
+			asc:        true,
 			inputs:     [][]uint32{nil, {4, 7, 9}, nil},
 			wantResult: []uint32{4, 7, 9},
 			wantResiduals: [][]uint32{
@@ -376,7 +376,7 @@ func TestLIDBatch_OrMulti(t *testing.T) {
 						batches[i] = impl.fn(lids)
 					}
 
-					result, residuals := OrMulti(batches, tc.desc)
+					result, residuals := OrMulti(batches, tc.asc)
 
 					assertSameSet(t, tc.wantResult, toSlice(result))
 					assert.Len(t, residuals, len(tc.wantResiduals))

--- a/node/batch_test.go
+++ b/node/batch_test.go
@@ -246,7 +246,7 @@ func TestBatchManyIter(t *testing.T) {
 
 	for _, impl := range batchFactories {
 		t.Run(impl.name, func(t *testing.T) {
-			t.Run("desc chunked", func(t *testing.T) {
+			t.Run("asc chunked", func(t *testing.T) {
 				b := impl.build(input)
 				it := b.ManyIter(true)
 				dst := make([]LID, 3)
@@ -266,7 +266,7 @@ func TestBatchManyIter(t *testing.T) {
 				assert.Equal(t, input, got)
 			})
 
-			t.Run("asc chunked", func(t *testing.T) {
+			t.Run("desc chunked", func(t *testing.T) {
 				b := impl.build(input)
 				it := b.ManyIter(false)
 				dst := make([]LID, 3)
@@ -286,7 +286,7 @@ func TestBatchManyIter(t *testing.T) {
 				assert.Equal(t, []uint32{30, 25, 20, 15, 10, 5, 1}, got)
 			})
 
-			t.Run("empty tmp yields zero for desc", func(t *testing.T) {
+			t.Run("empty tmp yields zero for asc", func(t *testing.T) {
 				b := impl.build(input)
 				n := b.ManyIter(true).CopyLIDs(make([]LID, 8), nil)
 				assert.Equal(t, 0, n)

--- a/node/bench_test.go
+++ b/node/bench_test.go
@@ -48,7 +48,7 @@ func BenchmarkNot(b *testing.B) {
 			r := rand.New(rand.NewSource(benchRandSeed))
 			v, last := Generate(r, s)
 			res := make([]uint32, 0, last+1)
-			n := NewNot(NewStatic(v, false), NewDescLID(1), NewDescLID(last))
+			n := NewNot(NewStatic(v, true), NewAscLID(1), NewAscLID(last))
 
 			for b.Loop() {
 				res = readAllInto(n, res)
@@ -65,7 +65,7 @@ func BenchmarkNotEmpty(b *testing.B) {
 	for _, s := range sizes {
 		b.Run(fmt.Sprintf("size=%d", s), func(b *testing.B) {
 			res := make([]uint32, 0, s*2)
-			n := NewNot(NewStatic(nil, false), NewDescLID(1), NewDescLID(uint32(s)))
+			n := NewNot(NewStatic(nil, true), NewAscLID(1), NewAscLID(uint32(s)))
 
 			for b.Loop() {
 				res = readAllInto(n, res)

--- a/node/builder.go
+++ b/node/builder.go
@@ -1,7 +1,7 @@
 package node
 
 var (
-	emptyNode        = NewStatic(nil, false)
+	emptyNode        = NewStatic(nil, true)
 	emptyNodeSourced = NewSourcedNodeWrapper(emptyNode, 0)
 )
 

--- a/node/lid.go
+++ b/node/lid.go
@@ -8,15 +8,15 @@ import (
 )
 
 const (
-	descMask = uint32(0)
-	ascMask  = uint32(0xFFFFFFFF)
+	ascMask  = uint32(0)
+	descMask = uint32(0xFFFFFFFF)
 )
 
-// LID is an encoded representation of LID and reverse flag made specifically for fast compare operations.
+// LID is an encoded representation of LID and order flag made specifically for fast compare operations.
 //
-// For reverse order LID is inverted as follows: "MaxUint32 - LID" formula using XOR mask. Terminal LID value is 0 instead
-// of MaxUint32 in reverse order, but 0 is XORed to MaxUint32. Which means, null value will always have lid field set to
-// 0xFFFFFFFF (math.MaxUint32) regardless of reverse (order) flag.
+// For descending LID order the value is inverted as follows: "MaxUint32 - LID" formula using XOR mask.
+// Terminal LID value is 0 instead of MaxUint32 in descending order, but 0 is XORed to MaxUint32.
+// Which means, null value will always have lid field set to 0xFFFFFFFF (math.MaxUint32) regardless of order flag.
 type LID struct {
 	lid  uint32 // do not read this field, use Unpack instead
 	mask uint32
@@ -24,39 +24,38 @@ type LID struct {
 
 func NullLID() LID {
 	// order does not matter, as null values are never unpacked
-	return NewDescLID(math.MaxUint32)
-}
-
-// NewDescLID returns LIDs for desc sort order
-func NewDescLID(lid uint32) LID {
-	return LID{
-		lid:  lid,
-		mask: descMask,
-	}
-}
-
-func NewDescZeroLID() LID {
-	return NewDescLID(0)
-}
-
-func NewAscZeroLID() LID {
 	return NewAscLID(math.MaxUint32)
 }
 
-// NewAscLID returns LIDs for asc sort order
+// NewAscLID returns LIDs for ascending LID order (low to high).
 func NewAscLID(lid uint32) LID {
 	return LID{
-		lid:  lid ^ ascMask,
+		lid:  lid,
 		mask: ascMask,
+	}
+}
+
+func NewAscZeroLID() LID {
+	return NewAscLID(0)
+}
+
+func NewDescZeroLID() LID {
+	return NewDescLID(math.MaxUint32)
+}
+
+// NewDescLID returns LIDs for descending LID order (high to low).
+func NewDescLID(lid uint32) LID {
+	return LID{
+		lid:  lid ^ descMask,
+		mask: descMask,
 	}
 }
 
 func NewLID(lid uint32, asc bool) LID {
 	if asc {
 		return NewAscLID(lid)
-	} else {
-		return NewDescLID(lid)
 	}
+	return NewDescLID(lid)
 }
 
 // Less compares two values. It also does an implicit null check, since we store math.MaxUint32 for null values.
@@ -82,17 +81,15 @@ func (c LID) Eq(other LID) bool {
 func Max(left, right LID) LID {
 	if left.lid > right.lid {
 		return left
-	} else {
-		return right
 	}
+	return right
 }
 
 func Min(left, right LID) LID {
 	if left.lid < right.lid {
 		return left
-	} else {
-		return right
 	}
+	return right
 }
 
 func (c LID) Unpack() uint32 {
@@ -108,5 +105,5 @@ func (c LID) IsNull() bool {
 }
 
 func (c LID) String() string {
-	return fmt.Sprintf("%d, reverse=%t", c.Unpack(), c.mask == ascMask)
+	return fmt.Sprintf("%d, asc=%t", c.Unpack(), c.mask == ascMask)
 }

--- a/node/lid.go
+++ b/node/lid.go
@@ -14,8 +14,9 @@ const (
 
 // LID is an encoded representation of LID and order flag made specifically for fast compare operations.
 //
-// For descending LID order the value is inverted as follows: "MaxUint32 - LID" formula using XOR mask.
-// Terminal LID value is 0 instead of MaxUint32 in descending order, but 0 is XORed to MaxUint32.
+// For asc LID order the value is stored as is and mask is zero.
+// For desc LID order the value is inverted as follows: "MaxUint32 - LID" formula using XOR mask.
+// Terminal LID value is 0 instead of MaxUint32 in desc order, but 0 is XORed to MaxUint32.
 // Which means, null value will always have lid field set to 0xFFFFFFFF (math.MaxUint32) regardless of order flag.
 type LID struct {
 	lid  uint32 // do not read this field, use Unpack instead
@@ -27,7 +28,7 @@ func NullLID() LID {
 	return NewAscLID(math.MaxUint32)
 }
 
-// NewAscLID returns LIDs for ascending LID order (low to high).
+// NewAscLID returns LIDs for asc LID order.
 func NewAscLID(lid uint32) LID {
 	return LID{
 		lid:  lid,
@@ -43,7 +44,7 @@ func NewDescZeroLID() LID {
 	return NewDescLID(math.MaxUint32)
 }
 
-// NewDescLID returns LIDs for descending LID order (high to low).
+// NewDescLID returns LIDs for desc LID order.
 func NewDescLID(lid uint32) LID {
 	return LID{
 		lid:  lid ^ descMask,

--- a/node/lid_test.go
+++ b/node/lid_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLID_Unpack_Desc(t *testing.T) {
-	x := NewDescLID(5)
+func TestLID_Unpack_Asc(t *testing.T) {
+	x := NewAscLID(5)
 	assert.Equal(t, uint32(5), x.Unpack())
 
-	x = NewDescLID(math.MaxUint32)
+	x = NewAscLID(math.MaxUint32)
 	assert.Equal(t, uint32(math.MaxUint32), x.Unpack())
 
-	x = NewDescLID(0)
+	x = NewAscLID(0)
 	assert.Equal(t, uint32(0), x.Unpack())
 
 	x = NullLID()
@@ -22,14 +22,14 @@ func TestLID_Unpack_Desc(t *testing.T) {
 	assert.True(t, x.IsNull())
 }
 
-func TestLID_Unpack_Asc(t *testing.T) {
-	x := NewAscLID(5)
+func TestLID_Unpack_Desc(t *testing.T) {
+	x := NewDescLID(5)
 	assert.Equal(t, uint32(5), x.Unpack())
 
-	x = NewAscLID(0)
+	x = NewDescLID(0)
 	assert.Equal(t, uint32(0), x.Unpack())
 
-	x = NewAscLID(math.MaxUint32)
+	x = NewDescLID(math.MaxUint32)
 	assert.Equal(t, uint32(math.MaxUint32), x.Unpack())
 
 	x = NullLID()
@@ -38,26 +38,26 @@ func TestLID_Unpack_Asc(t *testing.T) {
 }
 
 func TestLID_Eq(t *testing.T) {
-	assert.Equal(t, NewDescLID(6), NewDescLID(6))
-	assert.Equal(t, NewDescLID(math.MaxUint32), NewDescLID(math.MaxUint32))
-
 	assert.Equal(t, NewAscLID(6), NewAscLID(6))
-	assert.Equal(t, NewAscLID(0), NewAscLID(0))
-}
+	assert.Equal(t, NewAscLID(math.MaxUint32), NewAscLID(math.MaxUint32))
 
-func TestLID_Less_Desc(t *testing.T) {
-	assert.False(t, NewDescLID(6).Less(NewDescLID(6)))
-	assert.True(t, NewDescLID(6).Less(NewDescLID(7)))
-	assert.True(t, NewDescLID(0).Less(NewDescLID(5)))
-
-	assert.True(t, NewDescLID(56000).Less(NullLID()))
+	assert.Equal(t, NewDescLID(6), NewDescLID(6))
+	assert.Equal(t, NewDescLID(0), NewDescLID(0))
 }
 
 func TestLID_Less_Asc(t *testing.T) {
-	// for asc sort order larger values go first (order is reversed), i.e. greater values are "less" than lower values
 	assert.False(t, NewAscLID(6).Less(NewAscLID(6)))
-	assert.True(t, NewAscLID(10).Less(NewAscLID(1)))
-	assert.True(t, NewAscLID(5).Less(NewAscLID(0)))
+	assert.True(t, NewAscLID(6).Less(NewAscLID(7)))
+	assert.True(t, NewAscLID(0).Less(NewAscLID(5)))
 
 	assert.True(t, NewAscLID(56000).Less(NullLID()))
+}
+
+func TestLID_Less_Desc(t *testing.T) {
+	// for descending LID order larger values go first (order is reversed), i.e. greater values are "less" than lower values
+	assert.False(t, NewDescLID(6).Less(NewDescLID(6)))
+	assert.True(t, NewDescLID(10).Less(NewDescLID(1)))
+	assert.True(t, NewDescLID(5).Less(NewDescLID(0)))
+
+	assert.True(t, NewDescLID(56000).Less(NullLID()))
 }

--- a/node/node_and.go
+++ b/node/node_and.go
@@ -83,19 +83,19 @@ func (n *nodeAnd) NextGeq(nextID LID) LID {
 type nodeAndBatched struct {
 	left  BatchedNode
 	right BatchedNode
-	desc  bool
+	asc   bool
 
 	leftBatch  LIDBatch
 	rightBatch LIDBatch
 }
 
 // NewAndBatched returns a BatchedNode that intersects two batched iterators.
-// desc is the document traversal order for NextBatch / NextBatchGeq.
-func NewAndBatched(left, right BatchedNode, desc bool) BatchedNode {
+// asc is the LID traversal order for NextBatch / NextBatchGeq (true = low to high).
+func NewAndBatched(left, right BatchedNode, asc bool) BatchedNode {
 	return &nodeAndBatched{
 		left:       left,
 		right:      right,
-		desc:       desc,
+		asc:        asc,
 		leftBatch:  EmptyBatch(),
 		rightBatch: EmptyBatch(),
 	}
@@ -106,10 +106,10 @@ func (n *nodeAndBatched) String() string {
 }
 
 func (n *nodeAndBatched) NextBatch() LIDBatch {
-	if n.desc {
-		return n.NextBatchGeq(NewDescZeroLID())
+	if n.asc {
+		return n.NextBatchGeq(NewAscZeroLID())
 	}
-	return n.NextBatchGeq(NewAscZeroLID())
+	return n.NextBatchGeq(NewDescZeroLID())
 }
 
 func (n *nodeAndBatched) NextBatchGeq(nextID LID) LIDBatch {
@@ -124,7 +124,7 @@ func (n *nodeAndBatched) NextBatchGeq(nextID LID) LIDBatch {
 			return EmptyBatch()
 		}
 
-		inter, leftResidual, rightResidual := And(n.leftBatch, n.rightBatch, n.desc)
+		inter, leftResidual, rightResidual := And(n.leftBatch, n.rightBatch, n.asc)
 		n.leftBatch = leftResidual
 		n.rightBatch = rightResidual
 

--- a/node/node_and_test.go
+++ b/node/node_and_test.go
@@ -9,18 +9,18 @@ import (
 )
 
 func TestNodeAnd_NextGeqAscending(t *testing.T) {
-	left := NewStatic([]uint32{1, 2, 7, 10, 20, 25, 26, 30, 50, 80, 90, 100}, false)
-	right := NewStatic([]uint32{1, 3, 4, 7, 9, 30, 40, 45, 60, 80, 110}, false)
+	left := NewStatic([]uint32{1, 2, 7, 10, 20, 25, 26, 30, 50, 80, 90, 100}, true)
+	right := NewStatic([]uint32{1, 3, 4, 7, 9, 30, 40, 45, 60, 80, 110}, true)
 
 	node := NewAnd(left, right)
 
-	id := node.NextGeq(NewDescLID(7))
+	id := node.NextGeq(NewAscLID(7))
 	assert.Equal(t, uint32(7), id.Unpack())
 
-	id = node.NextGeq(NewDescLID(50))
+	id = node.NextGeq(NewAscLID(50))
 	assert.Equal(t, uint32(80), id.Unpack())
 
-	id = node.NextGeq(NewDescLID(50))
+	id = node.NextGeq(NewAscLID(50))
 	assert.True(t, id.IsNull())
 }
 
@@ -41,9 +41,9 @@ func TestNodeAnd_NextGeqCompatibility(t *testing.T) {
 
 		var zero uint32
 		if asc {
-			zero = math.MaxUint32
-		} else {
 			zero = 0
+		} else {
+			zero = math.MaxUint32
 		}
 
 		for {

--- a/node/node_nand.go
+++ b/node/node_nand.go
@@ -53,20 +53,22 @@ func (n *nodeNAnd) NextGeq(nextID LID) LID {
 }
 
 type nodeNAndBatched struct {
-	reg  BatchedNode
-	neg  BatchedNode
-	desc bool
+	reg BatchedNode
+	neg BatchedNode
+	asc bool
 
 	regBatch LIDBatch
 	negBatch LIDBatch
 	negDone  bool
 }
 
-func NewNAndBatched(neg, reg BatchedNode, desc bool) BatchedNode {
+// NewNAndBatched returns a BatchedNode that computes AND NOT of two batched iterators.
+// asc is the LID traversal order for NextBatch / NextBatchGeq (true = low to high).
+func NewNAndBatched(neg, reg BatchedNode, asc bool) BatchedNode {
 	return &nodeNAndBatched{
 		reg:      reg,
 		neg:      neg,
-		desc:     desc,
+		asc:      asc,
 		negDone:  false,
 		regBatch: EmptyBatch(),
 		negBatch: EmptyBatch(),
@@ -78,10 +80,10 @@ func (n *nodeNAndBatched) String() string {
 }
 
 func (n *nodeNAndBatched) NextBatch() LIDBatch {
-	if n.desc {
-		return n.NextBatchGeq(NewDescZeroLID())
+	if n.asc {
+		return n.NextBatchGeq(NewAscZeroLID())
 	}
-	return n.NextBatchGeq(NewAscZeroLID())
+	return n.NextBatchGeq(NewDescZeroLID())
 }
 
 func (n *nodeNAndBatched) NextBatchGeq(nextID LID) LIDBatch {
@@ -99,7 +101,7 @@ func (n *nodeNAndBatched) NextBatchGeq(nextID LID) LIDBatch {
 			}
 		}
 
-		result, regResidual, negResidual := AndNot(n.regBatch, n.negBatch, n.desc)
+		result, regResidual, negResidual := AndNot(n.regBatch, n.negBatch, n.asc)
 		n.regBatch = regResidual
 		n.negBatch = negResidual
 

--- a/node/node_nand_test.go
+++ b/node/node_nand_test.go
@@ -7,46 +7,46 @@ import (
 )
 
 func TestNodeNAnd_NextGeq(t *testing.T) {
-	neg := NewStatic([]uint32{1, 2, 7, 10, 20, 25, 26, 30, 50, 80, 90, 100}, false)
-	reg := NewStatic([]uint32{1, 3, 4, 7, 9, 30, 40, 45, 60, 80, 110}, false)
-
-	node := NewNAnd(neg, reg)
-
-	id := node.NextGeq(NewDescLID(7))
-	assert.Equal(t, uint32(9), id.Unpack())
-
-	id = node.NextGeq(NewDescLID(50))
-	assert.Equal(t, uint32(60), id.Unpack())
-
-	id = node.NextGeq(NewDescLID(100))
-	assert.Equal(t, uint32(110), id.Unpack())
-
-	id = node.NextGeq(NewDescLID(100))
-	assert.True(t, id.IsNull())
-}
-
-func TestNodeNAnd_NextGeq_Reverse(t *testing.T) {
 	neg := NewStatic([]uint32{1, 2, 7, 10, 20, 25, 26, 30, 50, 80, 90, 100}, true)
 	reg := NewStatic([]uint32{1, 3, 4, 7, 9, 30, 40, 45, 60, 80, 110}, true)
 
 	node := NewNAnd(neg, reg)
 
-	id := node.NextGeq(NewAscLID(80))
+	id := node.NextGeq(NewAscLID(7))
+	assert.Equal(t, uint32(9), id.Unpack())
+
+	id = node.NextGeq(NewAscLID(50))
 	assert.Equal(t, uint32(60), id.Unpack())
 
-	id = node.NextGeq(NewAscLID(49))
+	id = node.NextGeq(NewAscLID(100))
+	assert.Equal(t, uint32(110), id.Unpack())
+
+	id = node.NextGeq(NewAscLID(100))
+	assert.True(t, id.IsNull())
+}
+
+func TestNodeNAnd_NextGeq_Reverse(t *testing.T) {
+	neg := NewStatic([]uint32{1, 2, 7, 10, 20, 25, 26, 30, 50, 80, 90, 100}, false)
+	reg := NewStatic([]uint32{1, 3, 4, 7, 9, 30, 40, 45, 60, 80, 110}, false)
+
+	node := NewNAnd(neg, reg)
+
+	id := node.NextGeq(NewDescLID(80))
+	assert.Equal(t, uint32(60), id.Unpack())
+
+	id = node.NextGeq(NewDescLID(49))
 	assert.Equal(t, uint32(45), id.Unpack())
 
 	// call with same nextID, should just return next value
-	id = node.NextGeq(NewAscLID(49))
+	id = node.NextGeq(NewDescLID(49))
 	assert.Equal(t, uint32(40), id.Unpack())
 
-	id = node.NextGeq(NewAscLID(49))
+	id = node.NextGeq(NewDescLID(49))
 	assert.Equal(t, uint32(9), id.Unpack())
 
-	id = node.NextGeq(NewAscLID(4))
+	id = node.NextGeq(NewDescLID(4))
 	assert.Equal(t, uint32(4), id.Unpack())
 
-	id = node.NextGeq(NewAscLID(1))
+	id = node.NextGeq(NewDescLID(1))
 	assert.True(t, id.IsNull())
 }

--- a/node/node_or.go
+++ b/node/node_or.go
@@ -162,7 +162,7 @@ func (n *nodeOrAgg) NextSourcedGeq(nextID LID) (LID, uint32) {
 type nodeOrBatched struct {
 	left  BatchedNode
 	right BatchedNode
-	desc  bool
+	asc   bool
 
 	leftBatch  LIDBatch
 	rightBatch LIDBatch
@@ -171,12 +171,12 @@ type nodeOrBatched struct {
 }
 
 // NewOrBatched returns a BatchedNode that unions two batched iterators.
-// desc is the document traversal order for NextBatch / NextBatchGeq.
-func NewOrBatched(left, right BatchedNode, desc bool) BatchedNode {
+// asc is the LID traversal order for NextBatch / NextBatchGeq (true = low to high).
+func NewOrBatched(left, right BatchedNode, asc bool) BatchedNode {
 	return &nodeOrBatched{
 		left:       left,
 		right:      right,
-		desc:       desc,
+		asc:        asc,
 		leftBatch:  EmptyBatch(),
 		rightBatch: EmptyBatch(),
 	}
@@ -187,10 +187,10 @@ func (n *nodeOrBatched) String() string {
 }
 
 func (n *nodeOrBatched) NextBatch() LIDBatch {
-	if n.desc {
-		return n.NextBatchGeq(NewDescZeroLID())
+	if n.asc {
+		return n.NextBatchGeq(NewAscZeroLID())
 	}
-	return n.NextBatchGeq(NewAscZeroLID())
+	return n.NextBatchGeq(NewDescZeroLID())
 }
 
 func (n *nodeOrBatched) NextBatchGeq(nextID LID) LIDBatch {
@@ -209,7 +209,7 @@ func (n *nodeOrBatched) NextBatchGeq(nextID LID) LIDBatch {
 			return EmptyBatch()
 		}
 
-		out, leftRes, rightRes := Or(n.leftBatch, n.rightBatch, n.desc)
+		out, leftRes, rightRes := Or(n.leftBatch, n.rightBatch, n.asc)
 		n.leftBatch = leftRes
 		n.rightBatch = rightRes
 
@@ -221,13 +221,13 @@ func (n *nodeOrBatched) NextBatchGeq(nextID LID) LIDBatch {
 
 type nodeOrBatchedMulti struct {
 	children []BatchedNode
-	desc     bool
+	asc      bool
 
 	batches []LIDBatch
 	done    []bool
 }
 
-func NewOrBatchedMulti(children []BatchedNode, desc bool) BatchedNode {
+func NewOrBatchedMulti(children []BatchedNode, asc bool) BatchedNode {
 	if len(children) == 0 {
 		return EmptyBatched()
 	}
@@ -240,7 +240,7 @@ func NewOrBatchedMulti(children []BatchedNode, desc bool) BatchedNode {
 	}
 	return &nodeOrBatchedMulti{
 		children: children,
-		desc:     desc,
+		asc:      asc,
 		batches:  batches,
 		done:     make([]bool, len(children)),
 	}
@@ -251,10 +251,10 @@ func (n *nodeOrBatchedMulti) String() string {
 }
 
 func (n *nodeOrBatchedMulti) NextBatch() LIDBatch {
-	if n.desc {
-		return n.NextBatchGeq(NewDescZeroLID())
+	if n.asc {
+		return n.NextBatchGeq(NewAscZeroLID())
 	}
-	return n.NextBatchGeq(NewAscZeroLID())
+	return n.NextBatchGeq(NewDescZeroLID())
 }
 
 func (n *nodeOrBatchedMulti) NextBatchGeq(nextID LID) LIDBatch {
@@ -274,7 +274,7 @@ func (n *nodeOrBatchedMulti) NextBatchGeq(nextID LID) LIDBatch {
 			return EmptyBatch()
 		}
 
-		out, residuals := OrMulti(n.batches, n.desc)
+		out, residuals := OrMulti(n.batches, n.asc)
 		n.batches = residuals
 
 		if !out.IsEmpty() {

--- a/node/node_or_test.go
+++ b/node/node_or_test.go
@@ -10,24 +10,24 @@ import (
 )
 
 func TestNodeOr_NextGeqAscending(t *testing.T) {
-	left := NewStatic([]uint32{2, 7, 10, 20, 25, 26, 30, 50}, false)
-	right := NewStatic([]uint32{1, 3, 4, 7, 9, 30, 40}, false)
+	left := NewStatic([]uint32{2, 7, 10, 20, 25, 26, 30, 50}, true)
+	right := NewStatic([]uint32{1, 3, 4, 7, 9, 30, 40}, true)
 
 	node := NewOr(left, right)
 
-	id := node.NextGeq(NewDescLID(7))
+	id := node.NextGeq(NewAscLID(7))
 	assert.Equal(t, uint32(7), id.Unpack())
 
-	id = node.NextGeq(NewDescLID(7))
+	id = node.NextGeq(NewAscLID(7))
 	assert.Equal(t, uint32(9), id.Unpack())
 
-	id = node.NextGeq(NewDescLID(24))
+	id = node.NextGeq(NewAscLID(24))
 	assert.Equal(t, uint32(25), id.Unpack())
 
-	id = node.NextGeq(NewDescLID(30))
+	id = node.NextGeq(NewAscLID(30))
 	assert.Equal(t, uint32(30), id.Unpack())
 
-	id = node.NextGeq(NewDescLID(51))
+	id = node.NextGeq(NewAscLID(51))
 	assert.True(t, id.IsNull())
 }
 
@@ -48,9 +48,9 @@ func TestNodeOr_NextGeqCompatibility(t *testing.T) {
 
 		var zero uint32
 		if asc {
-			zero = math.MaxUint32
-		} else {
 			zero = 0
+		} else {
+			zero = math.MaxUint32
 		}
 
 		for {
@@ -68,8 +68,8 @@ func TestNodeOr_NextGeqCompatibility(t *testing.T) {
 
 // TestNodeOrAgg_NoDedup tests that nodeOrAgg yields values both from left and right for same lid.
 func TestNodeOrAgg_NoDedup(t *testing.T) {
-	left := NewSourcedNodeWrapper(NewStatic([]uint32{1, 5, 7}, false), 1)
-	right := NewSourcedNodeWrapper(NewStatic([]uint32{5, 8}, false), 2)
+	left := NewSourcedNodeWrapper(NewStatic([]uint32{1, 5, 7}, true), 1)
+	right := NewSourcedNodeWrapper(NewStatic([]uint32{5, 8}, true), 2)
 
 	orAgg := NewNodeOrAgg(left, right)
 	pairs := readAllSourced(orAgg)
@@ -89,8 +89,8 @@ func TestNodeOrAgg_NoDedup(t *testing.T) {
 }
 
 func TestNodeOrAgg_MergeAscending(t *testing.T) {
-	left := NewSourcedNodeWrapper(NewStatic([]uint32{1, 3, 5}, false), 0)
-	right := NewSourcedNodeWrapper(NewStatic([]uint32{2, 4, 6}, false), 1)
+	left := NewSourcedNodeWrapper(NewStatic([]uint32{1, 3, 5}, true), 0)
+	right := NewSourcedNodeWrapper(NewStatic([]uint32{2, 4, 6}, true), 1)
 
 	orAgg := NewNodeOrAgg(left, right)
 	got := readAllSourced(orAgg)
@@ -108,8 +108,8 @@ func TestNodeOrAgg_MergeAscending(t *testing.T) {
 }
 
 func TestNodeOrAgg_MergeAscendingWithDups(t *testing.T) {
-	left := NewSourcedNodeWrapper(NewStatic([]uint32{1, 2, 3, 5, 8}, false), 0)
-	right := NewSourcedNodeWrapper(NewStatic([]uint32{2, 3, 4, 6, 8}, false), 1)
+	left := NewSourcedNodeWrapper(NewStatic([]uint32{1, 2, 3, 5, 8}, true), 0)
+	right := NewSourcedNodeWrapper(NewStatic([]uint32{2, 3, 4, 6, 8}, true), 1)
 
 	orAgg := NewNodeOrAgg(left, right)
 	got := readAllSourced(orAgg)
@@ -133,25 +133,25 @@ func TestNodeOrAgg_MergeAscendingWithDups(t *testing.T) {
 // TestNodeOrAgg_NextSourcedGeq tests we can navigate to a lid with NextGeq and do not skip it from
 // both left and right sides (no deduplication like in ordinary OR tree)
 func TestNodeOrAgg_NextSourcedGeq(t *testing.T) {
-	left := NewSourcedNodeWrapper(NewStatic([]uint32{1, 2, 3, 5, 8, 15, 19}, false), 0)
-	right := NewSourcedNodeWrapper(NewStatic([]uint32{2, 3, 4, 6, 8, 14, 20}, false), 1)
+	left := NewSourcedNodeWrapper(NewStatic([]uint32{1, 2, 3, 5, 8, 15, 19}, true), 0)
+	right := NewSourcedNodeWrapper(NewStatic([]uint32{2, 3, 4, 6, 8, 14, 20}, true), 1)
 
 	orAgg := NewNodeOrAgg(left, right)
 
-	id, source := orAgg.NextSourcedGeq(NewDescLID(3))
+	id, source := orAgg.NextSourcedGeq(NewAscLID(3))
 	assert.Equal(t, uint32(3), id.Unpack())
 	assert.Equal(t, uint32(1), source)
 
 	// 3 returned again, but with different source - no deduplication
-	id, source = orAgg.NextSourcedGeq(NewDescLID(3))
+	id, source = orAgg.NextSourcedGeq(NewAscLID(3))
 	assert.Equal(t, uint32(3), id.Unpack())
 	assert.Equal(t, uint32(0), source)
 
-	id, source = orAgg.NextSourcedGeq(NewDescLID(6))
+	id, source = orAgg.NextSourcedGeq(NewAscLID(6))
 	assert.Equal(t, uint32(6), id.Unpack())
 	assert.Equal(t, uint32(1), source)
 
-	id, source = orAgg.NextSourcedGeq(NewDescLID(17))
+	id, source = orAgg.NextSourcedGeq(NewAscLID(17))
 	assert.Equal(t, uint32(19), id.Unpack())
 	assert.Equal(t, uint32(0), source)
 }
@@ -159,35 +159,35 @@ func TestNodeOrAgg_NextSourcedGeq(t *testing.T) {
 // TestNodeOrAgg_NextSourcedGeq tests we can navigate to a lid with NextGeq in reverse way and do not skip it from
 // both left and right sides (no deduplication like in ordinary OR tree)
 func TestNodeOrAgg_NextSourcedGeq_Reverse(t *testing.T) {
-	left := NewSourcedNodeWrapper(NewStatic([]uint32{1, 2, 3, 5, 8, 15, 19}, true), 0)
-	right := NewSourcedNodeWrapper(NewStatic([]uint32{2, 3, 4, 6, 8, 14, 20}, true), 1)
+	left := NewSourcedNodeWrapper(NewStatic([]uint32{1, 2, 3, 5, 8, 15, 19}, false), 0)
+	right := NewSourcedNodeWrapper(NewStatic([]uint32{2, 3, 4, 6, 8, 14, 20}, false), 1)
 
 	orAgg := NewNodeOrAgg(left, right)
 
-	id, source := orAgg.NextSourcedGeq(NewAscLID(8))
+	id, source := orAgg.NextSourcedGeq(NewDescLID(8))
 	assert.Equal(t, uint32(8), id.Unpack())
 	assert.Equal(t, uint32(1), source)
 
 	// 8 returned again, but with different source - no deduplication
-	id, source = orAgg.NextSourcedGeq(NewAscLID(8))
+	id, source = orAgg.NextSourcedGeq(NewDescLID(8))
 	assert.Equal(t, uint32(8), id.Unpack())
 	assert.Equal(t, uint32(0), source)
 
-	id, source = orAgg.NextSourcedGeq(NewAscLID(4))
+	id, source = orAgg.NextSourcedGeq(NewDescLID(4))
 	assert.Equal(t, uint32(4), id.Unpack())
 	assert.Equal(t, uint32(1), source)
 
-	id, source = orAgg.NextSourcedGeq(NewAscLID(1))
+	id, source = orAgg.NextSourcedGeq(NewDescLID(1))
 	assert.Equal(t, uint32(1), id.Unpack())
 	assert.Equal(t, uint32(0), source)
 
-	id, _ = orAgg.NextSourcedGeq(NewAscLID(1))
+	id, _ = orAgg.NextSourcedGeq(NewDescLID(1))
 	assert.True(t, id.IsNull())
 }
 
 func TestNodeOrAgg_MergeDescending(t *testing.T) {
-	left := NewSourcedNodeWrapper(NewStatic([]uint32{1, 3, 5}, true), 0)
-	right := NewSourcedNodeWrapper(NewStatic([]uint32{2, 4, 6}, true), 1)
+	left := NewSourcedNodeWrapper(NewStatic([]uint32{1, 3, 5}, false), 0)
+	right := NewSourcedNodeWrapper(NewStatic([]uint32{2, 4, 6}, false), 1)
 
 	orAgg := NewNodeOrAgg(left, right)
 	got := readAllSourced(orAgg)
@@ -206,8 +206,8 @@ func TestNodeOrAgg_MergeDescending(t *testing.T) {
 
 func TestNodeOrAgg_EmptySide(t *testing.T) {
 	t.Run("empty_left", func(t *testing.T) {
-		left := NewSourcedNodeWrapper(NewStatic(nil, false), 0)
-		right := NewSourcedNodeWrapper(NewStatic([]uint32{10, 20}, false), 1)
+		left := NewSourcedNodeWrapper(NewStatic(nil, true), 0)
+		right := NewSourcedNodeWrapper(NewStatic([]uint32{10, 20}, true), 1)
 
 		orAgg := NewNodeOrAgg(left, right)
 		got := readAllSourced(orAgg)
@@ -221,8 +221,8 @@ func TestNodeOrAgg_EmptySide(t *testing.T) {
 	})
 
 	t.Run("empty_right", func(t *testing.T) {
-		left := NewSourcedNodeWrapper(NewStatic([]uint32{10, 20}, false), 0)
-		right := NewSourcedNodeWrapper(NewStatic(nil, false), 1)
+		left := NewSourcedNodeWrapper(NewStatic([]uint32{10, 20}, true), 0)
+		right := NewSourcedNodeWrapper(NewStatic(nil, true), 1)
 
 		orAgg := NewNodeOrAgg(left, right)
 		got := readAllSourced(orAgg)
@@ -236,8 +236,8 @@ func TestNodeOrAgg_EmptySide(t *testing.T) {
 	})
 
 	t.Run("both_empty", func(t *testing.T) {
-		left := NewSourcedNodeWrapper(NewStatic(nil, false), 0)
-		right := NewSourcedNodeWrapper(NewStatic(nil, false), 1)
+		left := NewSourcedNodeWrapper(NewStatic(nil, true), 0)
+		right := NewSourcedNodeWrapper(NewStatic(nil, true), 1)
 
 		orAgg := NewNodeOrAgg(left, right)
 		id, _ := orAgg.NextSourced()

--- a/node/node_range_test.go
+++ b/node/node_range_test.go
@@ -7,50 +7,50 @@ import (
 )
 
 func TestNodeRange_NextGeq_JumpToLast(t *testing.T) {
-	node := NewRange(NewDescLID(3), NewDescLID(10))
+	node := NewRange(NewAscLID(3), NewAscLID(10))
 
-	id := node.NextGeq(NewDescLID(10))
+	id := node.NextGeq(NewAscLID(10))
 	assert.Equal(t, uint32(10), id.Unpack())
 }
 
 func TestNodeRange_NextGeq_SkipsWholeRange(t *testing.T) {
-	node := NewRange(NewDescLID(3), NewDescLID(10))
+	node := NewRange(NewAscLID(3), NewAscLID(10))
 
-	id := node.NextGeq(NewDescLID(11))
+	id := node.NextGeq(NewAscLID(11))
 	assert.True(t, id.IsNull())
 }
 
 func TestNodeRange_NextGeq(t *testing.T) {
-	node := NewRange(NewDescLID(3), NewDescLID(10))
+	node := NewRange(NewAscLID(3), NewAscLID(10))
 
-	id := node.NextGeq(NewDescLID(5))
+	id := node.NextGeq(NewAscLID(5))
 	assert.Equal(t, uint32(5), id.Unpack())
 
-	id = node.NextGeq(NewDescLID(5))
+	id = node.NextGeq(NewAscLID(5))
 	assert.Equal(t, uint32(6), id.Unpack())
 
-	id = node.NextGeq(NewDescLID(10))
+	id = node.NextGeq(NewAscLID(10))
 	assert.Equal(t, uint32(10), id.Unpack())
 
-	id = node.NextGeq(NewDescLID(10))
+	id = node.NextGeq(NewAscLID(10))
 	assert.True(t, id.IsNull())
 }
 
 func TestNodeRange_NextGeq_Reverse(t *testing.T) {
-	node := NewRange(NewAscLID(10), NewAscLID(3))
+	node := NewRange(NewDescLID(10), NewDescLID(3))
 
-	id := node.NextGeq(NewAscLID(9))
+	id := node.NextGeq(NewDescLID(9))
 	assert.Equal(t, uint32(9), id.Unpack())
 
-	id = node.NextGeq(NewAscLID(9))
+	id = node.NextGeq(NewDescLID(9))
 	assert.Equal(t, uint32(8), id.Unpack())
 
-	id = node.NextGeq(NewAscLID(4))
+	id = node.NextGeq(NewDescLID(4))
 	assert.Equal(t, uint32(4), id.Unpack())
 
-	id = node.NextGeq(NewAscLID(3))
+	id = node.NextGeq(NewDescLID(3))
 	assert.Equal(t, uint32(3), id.Unpack())
 
-	id = node.NextGeq(NewAscLID(3))
+	id = node.NextGeq(NewDescLID(3))
 	assert.True(t, id.IsNull())
 }

--- a/node/node_static.go
+++ b/node/node_static.go
@@ -15,7 +15,7 @@ type staticAsc struct {
 	staticCursor
 }
 
-// staticAsc stores lids in data slice in ascending order, but iterates from the end (in descending order)
+// staticDesc stores lids in data slice in ascending order, but iterates from the end (in descending order)
 type staticDesc struct {
 	staticCursor
 }
@@ -24,8 +24,10 @@ func (n *staticCursor) String() string {
 	return "STATIC"
 }
 
-func NewStatic(data []uint32, reverse bool) Node {
-	if reverse {
+// NewStatic returns a Node over sorted LID data.
+// asc=true iterates low to high; asc=false iterates high to low.
+func NewStatic(data []uint32, asc bool) Node {
+	if !asc {
 		return &staticDesc{staticCursor: staticCursor{
 			ptr:  len(data) - 1,
 			data: data,
@@ -39,13 +41,13 @@ func NewStatic(data []uint32, reverse bool) Node {
 }
 
 func (n *staticAsc) Next() LID {
-	// staticAsc is used in docs order desc, hence we return LID with desc order
+	// LID ascending: return AscLID
 	if n.ptr >= len(n.data) {
-		return NewDescLID(math.MaxUint32)
+		return NewAscLID(math.MaxUint32)
 	}
 	cur := n.data[n.ptr]
 	n.ptr++
-	return NewDescLID(cur)
+	return NewAscLID(cur)
 }
 
 // NextGeq finds next greater or equals since iteration is in ascending order
@@ -63,17 +65,17 @@ func (n *staticAsc) NextGeq(nextID LID) LID {
 	i := from + idx
 	cur := n.data[i]
 	n.ptr = i + 1
-	return NewDescLID(cur)
+	return NewAscLID(cur)
 }
 
 func (n *staticDesc) Next() LID {
-	// staticDesc is used in docs order asc, hence we return LID with asc order
+	// LID descending: return DescLID
 	if n.ptr < 0 {
-		return NewAscLID(0)
+		return NewDescLID(0)
 	}
 	cur := n.data[n.ptr]
 	n.ptr--
-	return NewAscLID(cur)
+	return NewDescLID(cur)
 }
 
 // NextGeq finds next less or equals since iteration is in descending order
@@ -88,14 +90,14 @@ func (n *staticDesc) NextGeq(nextID LID) LID {
 
 	cur := n.data[idx]
 	n.ptr = idx - 1
-	return NewAscLID(cur)
+	return NewDescLID(cur)
 }
 
 // MakeStaticNodes is currently used only for tests
 func MakeStaticNodes(data [][]uint32) []Node {
 	nodes := make([]Node, len(data))
 	for i, values := range data {
-		nodes[i] = NewStatic(values, false)
+		nodes[i] = NewStatic(values, true)
 	}
 	return nodes
 }
@@ -110,8 +112,10 @@ type staticBatchedDesc struct {
 	batch LIDBatch
 }
 
-func NewStaticBatched(data []uint32, reverse bool) BatchedNode {
-	if reverse {
+// NewStaticBatched returns a BatchedNode over sorted LID data.
+// asc=true iterates low to high; asc=false iterates high to low.
+func NewStaticBatched(data []uint32, asc bool) BatchedNode {
+	if !asc {
 		return &staticBatchedDesc{staticCursor: staticCursor{
 			ptr:  len(data) - 1,
 			data: data,
@@ -129,7 +133,7 @@ func (n *staticBatchedAsc) String() string {
 }
 
 func (n *staticBatchedAsc) NextBatch() LIDBatch {
-	return n.NextBatchGeq(NewDescZeroLID())
+	return n.NextBatchGeq(NewAscZeroLID())
 }
 
 func (n *staticBatchedAsc) NextBatchGeq(nextID LID) LIDBatch {
@@ -161,7 +165,7 @@ func (n *staticBatchedDesc) String() string {
 }
 
 func (n *staticBatchedDesc) NextBatch() LIDBatch {
-	return n.NextBatchGeq(NewAscZeroLID())
+	return n.NextBatchGeq(NewDescZeroLID())
 }
 
 func (n *staticBatchedDesc) NextBatchGeq(nextID LID) LIDBatch {

--- a/node/node_static.go
+++ b/node/node_static.go
@@ -10,12 +10,12 @@ type staticCursor struct {
 	data []uint32
 }
 
-// staticAsc stores lids in data slice in ascending order, and iterates in increasing order
+// staticAsc iterates in asc order. Data is always stored in asc order as well.
 type staticAsc struct {
 	staticCursor
 }
 
-// staticDesc stores lids in data slice in ascending order, but iterates from the end (in descending order)
+// staticDesc iterates in desc order. Data is always stored in asc order.
 type staticDesc struct {
 	staticCursor
 }
@@ -24,8 +24,6 @@ func (n *staticCursor) String() string {
 	return "STATIC"
 }
 
-// NewStatic returns a Node over sorted LID data.
-// asc=true iterates low to high; asc=false iterates high to low.
 func NewStatic(data []uint32, asc bool) Node {
 	if !asc {
 		return &staticDesc{staticCursor: staticCursor{
@@ -41,7 +39,6 @@ func NewStatic(data []uint32, asc bool) Node {
 }
 
 func (n *staticAsc) Next() LID {
-	// LID ascending: return AscLID
 	if n.ptr >= len(n.data) {
 		return NewAscLID(math.MaxUint32)
 	}
@@ -69,7 +66,6 @@ func (n *staticAsc) NextGeq(nextID LID) LID {
 }
 
 func (n *staticDesc) Next() LID {
-	// LID descending: return DescLID
 	if n.ptr < 0 {
 		return NewDescLID(0)
 	}
@@ -113,7 +109,6 @@ type staticBatchedDesc struct {
 }
 
 // NewStaticBatched returns a BatchedNode over sorted LID data.
-// asc=true iterates low to high; asc=false iterates high to low.
 func NewStaticBatched(data []uint32, asc bool) BatchedNode {
 	if !asc {
 		return &staticBatchedDesc{staticCursor: staticCursor{

--- a/node/node_static_test.go
+++ b/node/node_static_test.go
@@ -8,28 +8,28 @@ import (
 
 func TestStaticAscNextGeq(t *testing.T) {
 	lids := []uint32{1, 3, 5, 7, 9}
-	n := NewStatic(lids, false).(*staticAsc)
+	n := NewStatic(lids, true).(*staticAsc)
 
-	id := n.NextGeq(NewDescLID(0))
+	id := n.NextGeq(NewAscLID(0))
 	assert.False(t, id.IsNull())
 	assert.Equal(t, uint32(1), id.Unpack())
 
-	id = n.NextGeq(NewDescLID(4))
+	id = n.NextGeq(NewAscLID(4))
 	assert.False(t, id.IsNull())
 	assert.Equal(t, uint32(5), id.Unpack())
 
 	// 5 has already been returned, so the next value >= 5 is 7.
-	id = n.NextGeq(NewDescLID(5))
+	id = n.NextGeq(NewAscLID(5))
 	assert.False(t, id.IsNull())
 	assert.Equal(t, uint32(7), id.Unpack())
 
-	id = n.NextGeq(NewDescLID(10))
+	id = n.NextGeq(NewAscLID(10))
 	assert.True(t, id.IsNull())
 }
 
 func TestStaticDescNextGeq(t *testing.T) {
 	lids := []uint32{1, 3, 5, 7, 9}
-	n := NewStatic(lids, true).(*staticDesc)
+	n := NewStatic(lids, false).(*staticDesc)
 
 	id := n.NextGeq(NewDescLID(10))
 	assert.False(t, id.IsNull())
@@ -46,7 +46,7 @@ func TestStaticDescNextGeq(t *testing.T) {
 
 func TestStaticDescNextGeq_WithThreshold(t *testing.T) {
 	lids := []uint32{1, 3, 5, 7, 9}
-	n := NewStatic(lids, true).(*staticDesc)
+	n := NewStatic(lids, false).(*staticDesc)
 
 	id := n.NextGeq(NewDescLID(8))
 	assert.False(t, id.IsNull())

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -42,85 +42,85 @@ var (
 
 func TestNodeAnd(t *testing.T) {
 	expect := []uint32{5, 6, 13}
-	and := NewAnd(NewStatic(data[0], false), NewStatic(data[1], false))
+	and := NewAnd(NewStatic(data[0], true), NewStatic(data[1], true))
 	assert.Equal(t, expect, readAll(and))
 
 	// commutativity test
-	and2 := NewAnd(NewStatic(data[1], false), NewStatic(data[0], false))
+	and2 := NewAnd(NewStatic(data[1], true), NewStatic(data[0], true))
 	assert.Equal(t, expect, readAll(and2))
 }
 
 func TestNodeOr(t *testing.T) {
 	expect := []uint32{1, 2, 3, 5, 6, 7, 8, 9, 13, 14}
-	or := NewOr(NewStatic(data[0], false), NewStatic(data[1], false))
+	or := NewOr(NewStatic(data[0], true), NewStatic(data[1], true))
 	assert.Equal(t, expect, readAll(or))
 
 	// commutativity test
-	or2 := NewOr(NewStatic(data[1], false), NewStatic(data[0], false))
+	or2 := NewOr(NewStatic(data[1], true), NewStatic(data[0], true))
 	assert.Equal(t, expect, readAll(or2))
 }
 
 func TestNodeNAnd(t *testing.T) {
 	expect := []uint32{2, 3, 14}
-	nand := NewNAnd(NewStatic(data[0], false), NewStatic(data[1], false))
+	nand := NewNAnd(NewStatic(data[0], true), NewStatic(data[1], true))
 	assert.Equal(t, expect, readAll(nand))
 }
 
 func TestNodeAndReverse(t *testing.T) {
 	expect := []uint32{13, 6, 5}
-	and := NewAnd(NewStatic(data[0], true), NewStatic(data[1], true))
+	and := NewAnd(NewStatic(data[0], false), NewStatic(data[1], false))
 	assert.Equal(t, expect, readAll(and))
 }
 
 func TestNodeOrReverse(t *testing.T) {
 	expect := []uint32{14, 13, 9, 8, 7, 6, 5, 3, 2, 1}
-	or := NewOr(NewStatic(data[0], true), NewStatic(data[1], true))
+	or := NewOr(NewStatic(data[0], false), NewStatic(data[1], false))
 	assert.Equal(t, expect, readAll(or))
 
 	// commutativity test
-	or2 := NewOr(NewStatic(data[0], true), NewStatic(data[1], true))
+	or2 := NewOr(NewStatic(data[0], false), NewStatic(data[1], false))
 	assert.Equal(t, expect, readAll(or2))
 }
 
 func TestNodeNAndReverse(t *testing.T) {
 	expect := []uint32{14, 3, 2}
-	nand := NewNAnd(NewStatic(data[0], true), NewStatic(data[1], true))
+	nand := NewNAnd(NewStatic(data[0], false), NewStatic(data[1], false))
 	assert.Equal(t, expect, readAll(nand))
 }
 
 func TestNodeNotReverse(t *testing.T) {
 	expect := []uint32{15, 12, 11, 10, 9, 8, 7, 4, 1}
-	not := NewNot(NewStatic(data[1], true), NewAscLID(15), NewAscLID(1))
+	not := NewNot(NewStatic(data[1], false), NewDescLID(15), NewDescLID(1))
 	assert.Equal(t, expect, readAll(not))
 }
 
 func TestNodeRange(t *testing.T) {
 	expect := []uint32{3, 4, 5, 6, 7, 8, 9, 10}
-	not := NewRange(NewDescLID(3), NewDescLID(10))
+	not := NewRange(NewAscLID(3), NewAscLID(10))
 	assert.Equal(t, expect, readAll(not))
 }
 
 func TestNodeRangeReverse(t *testing.T) {
 	expect := []uint32{10, 9, 8, 7, 6, 5, 4, 3}
-	not := NewRange(NewAscLID(10), NewAscLID(3))
+	not := NewRange(NewDescLID(10), NewDescLID(3))
 	assert.Equal(t, expect, readAll(not))
 }
 
 func TestNodeNotPartialRange(t *testing.T) {
 	expect := []uint32{4, 7, 8, 9, 10}
-	not := NewNot(NewStatic(data[1], false), NewDescLID(3), NewDescLID(10))
+	not := NewNot(NewStatic(data[1], true), NewAscLID(3), NewAscLID(10))
 	assert.Equal(t, expect, readAll(not))
 }
 
 func TestNodeNotPartialRangeReverse(t *testing.T) {
 	expect := []uint32{10, 9, 8, 7, 4}
-	not := NewNot(NewStatic(data[1], true), NewAscLID(10), NewAscLID(3))
+	not := NewNot(NewStatic(data[1], false), NewDescLID(10), NewDescLID(3))
 	assert.Equal(t, expect, readAll(not))
 }
 
 func TestNodeNot(t *testing.T) {
 	expect := []uint32{1, 4, 7, 8, 9, 10, 11, 12, 15}
-	nand := NewNot(NewStatic(data[1], false), NewDescLID(1), NewDescLID(15))
+	nand := NewNot(NewStatic(data[1], true), NewAscLID(1), NewAscLID(15))
 	assert.Equal(t, expect, readAll(nand))
 }
 
@@ -128,7 +128,7 @@ func TestNodeNot(t *testing.T) {
 func TestNodeLazyAnd(t *testing.T) {
 	left := []uint32{1, 2}
 	right := []uint32{1, 2, 3, 4, 5, 6}
-	and := NewAnd(NewStatic(left, false), NewStatic(right, false))
+	and := NewAnd(NewStatic(left, true), NewStatic(right, true))
 	assert.Equal(t, []uint32{1, 2}, readAll(and))
 	assert.Equal(t, []uint32{4, 5, 6}, getRemainingSlice(t, and.right))
 	assert.Equal(t, []uint32(nil), readAll(and))
@@ -139,7 +139,7 @@ func TestNodeLazyAnd(t *testing.T) {
 func TestNodeLazyNAnd(t *testing.T) {
 	left := []uint32{1, 2, 5, 6, 7, 8}
 	right := []uint32{2, 4}
-	nand := NewNAnd(NewStatic(left, false), NewStatic(right, false))
+	nand := NewNAnd(NewStatic(left, true), NewStatic(right, true))
 	assert.Equal(t, []uint32{4}, readAll(nand))
 	assert.Equal(t, []uint32{6, 7, 8}, getRemainingSlice(t, nand.neg))
 	assert.Equal(t, []uint32(nil), readAll(nand))

--- a/node/util.go
+++ b/node/util.go
@@ -12,14 +12,14 @@ const maxBatchDrain = 4 * 1024
 // the underlying slice is reused.
 type batcherNode struct {
 	source Node
-	desc   bool
+	asc    bool
 	batch  []uint32
 }
 
-func NewBatcherNode(source Node, desc bool) BatchedNode {
+func NewBatcherNode(source Node, asc bool) BatchedNode {
 	return &batcherNode{
 		source: source,
-		desc:   desc,
+		asc:    asc,
 		batch:  make([]uint32, 0, maxBatchDrain),
 	}
 }
@@ -33,7 +33,7 @@ func (b *batcherNode) NextBatch() LIDBatch {
 		}
 		b.batch = append(b.batch, lid.Unpack())
 	}
-	if !b.desc {
+	if !b.asc {
 		slices.Reverse(b.batch)
 	}
 	return NewSliceBatch(b.batch)
@@ -48,7 +48,7 @@ func (b *batcherNode) NextBatchGeq(nextID LID) LIDBatch {
 		}
 		b.batch = append(b.batch, lid.Unpack())
 	}
-	if !b.desc {
+	if !b.asc {
 		slices.Reverse(b.batch)
 	}
 	return NewSliceBatch(b.batch)

--- a/skipmaskmanager/iterator_asc.go
+++ b/skipmaskmanager/iterator_asc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ozontech/seq-db/node"
 )
 
+// IteratorAsc iterates skip-mask LIDs in ascending order (low to high).
 type IteratorAsc Iterator
 
 func (it *IteratorAsc) String() string {
@@ -20,7 +21,6 @@ func (it *IteratorAsc) Next() node.LID {
 			logger.Panic("can't load skip mask file headers", zap.Error(err))
 		}
 		it.loader.headers = headers
-		it.blockIndex = len(it.loader.headers) - 1
 	}
 
 	for len(it.lids) == 0 {
@@ -32,9 +32,8 @@ func (it *IteratorAsc) Next() node.LID {
 		it.lids = (*Iterator)(it).narrowLIDsRange(it.lids)
 	}
 
-	i := len(it.lids) - 1
-	lid := it.lids[i]
-	it.lids = it.lids[:i]
+	lid := it.lids[0]
+	it.lids = it.lids[1:]
 	return node.NewAscLID(lid)
 }
 
@@ -67,6 +66,6 @@ func (it *IteratorAsc) loadNextLIDsBlock() {
 }
 
 func (it *IteratorAsc) needTryNextBlock() {
-	it.tryNextBlock = it.blockIndex > 0
-	it.blockIndex--
+	it.tryNextBlock = it.blockIndex < len(it.loader.headers)-1
+	it.blockIndex++
 }

--- a/skipmaskmanager/iterator_asc.go
+++ b/skipmaskmanager/iterator_asc.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ozontech/seq-db/node"
 )
 
-// IteratorAsc iterates skip-mask LIDs in ascending order (low to high).
+// IteratorAsc iterates skip-mask LIDs in asc order.
 type IteratorAsc Iterator
 
 func (it *IteratorAsc) String() string {

--- a/skipmaskmanager/iterator_asc_test.go
+++ b/skipmaskmanager/iterator_asc_test.go
@@ -4,7 +4,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,10 +19,6 @@ func TestIteratorAsc(t *testing.T) {
 		multipleBlocksLIDs = append(multipleBlocksLIDs, seq.LID(i+1))
 	}
 
-	reversed := make([]uint32, len(multipleBlocksLIDs))
-	copy(reversed, lidsToUint32s(multipleBlocksLIDs))
-	slices.Reverse(reversed)
-
 	type testCase struct {
 		title          string
 		minLID, maxLID uint32
@@ -35,13 +30,13 @@ func TestIteratorAsc(t *testing.T) {
 			title:    "ok_without_borders",
 			minLID:   0,
 			maxLID:   math.MaxUint32,
-			expected: reversed,
+			expected: lidsToUint32s(multipleBlocksLIDs),
 		},
 		{
 			title:    "ok_with_borders",
 			minLID:   maxLIDsBlockLen + 11,
 			maxLID:   uint32(len(multipleBlocksLIDs) - (maxLIDsBlockLen + 11)),
-			expected: reversed[maxLIDsBlockLen+11 : len(multipleBlocksLIDs)-(maxLIDsBlockLen+10)],
+			expected: lidsToUint32s(multipleBlocksLIDs[maxLIDsBlockLen+10 : len(multipleBlocksLIDs)-(maxLIDsBlockLen+11)]),
 		},
 		{
 			title:    "ok_out_of_borders",

--- a/skipmaskmanager/iterator_desc.go
+++ b/skipmaskmanager/iterator_desc.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ozontech/seq-db/node"
 )
 
-// IteratorDesc iterates skip-mask LIDs in descending order (high to low).
+// IteratorDesc iterates skip-mask LIDs in desc order.
 type IteratorDesc Iterator
 
 func (it *IteratorDesc) String() string {

--- a/skipmaskmanager/iterator_desc.go
+++ b/skipmaskmanager/iterator_desc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ozontech/seq-db/node"
 )
 
+// IteratorDesc iterates skip-mask LIDs in descending order (high to low).
 type IteratorDesc Iterator
 
 func (it *IteratorDesc) String() string {
@@ -20,6 +21,7 @@ func (it *IteratorDesc) Next() node.LID {
 			logger.Panic("can't load skip mask file headers", zap.Error(err))
 		}
 		it.loader.headers = headers
+		it.blockIndex = len(it.loader.headers) - 1
 	}
 
 	for len(it.lids) == 0 {
@@ -31,8 +33,9 @@ func (it *IteratorDesc) Next() node.LID {
 		it.lids = (*Iterator)(it).narrowLIDsRange(it.lids)
 	}
 
-	lid := it.lids[0]
-	it.lids = it.lids[1:]
+	i := len(it.lids) - 1
+	lid := it.lids[i]
+	it.lids = it.lids[:i]
 	return node.NewDescLID(lid)
 }
 
@@ -65,6 +68,6 @@ func (it *IteratorDesc) loadNextLIDsBlock() {
 }
 
 func (it *IteratorDesc) needTryNextBlock() {
-	it.tryNextBlock = it.blockIndex < len(it.loader.headers)-1
-	it.blockIndex++
+	it.tryNextBlock = it.blockIndex > 0
+	it.blockIndex--
 }

--- a/skipmaskmanager/iterator_desc_test.go
+++ b/skipmaskmanager/iterator_desc_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,6 +20,10 @@ func TestIteratorDesc(t *testing.T) {
 		multipleBlocksLIDs = append(multipleBlocksLIDs, seq.LID(i+1))
 	}
 
+	reversed := make([]uint32, len(multipleBlocksLIDs))
+	copy(reversed, lidsToUint32s(multipleBlocksLIDs))
+	slices.Reverse(reversed)
+
 	type testCase struct {
 		title          string
 		minLID, maxLID uint32
@@ -30,13 +35,13 @@ func TestIteratorDesc(t *testing.T) {
 			title:    "ok_without_borders",
 			minLID:   0,
 			maxLID:   math.MaxUint32,
-			expected: lidsToUint32s(multipleBlocksLIDs),
+			expected: reversed,
 		},
 		{
 			title:    "ok_with_borders",
 			minLID:   maxLIDsBlockLen + 11,
 			maxLID:   uint32(len(multipleBlocksLIDs) - (maxLIDsBlockLen + 11)),
-			expected: lidsToUint32s(multipleBlocksLIDs[maxLIDsBlockLen+10 : len(multipleBlocksLIDs)-(maxLIDsBlockLen+11)]),
+			expected: reversed[maxLIDsBlockLen+11 : len(multipleBlocksLIDs)-(maxLIDsBlockLen+10)],
 		},
 		{
 			title:    "ok_out_of_borders",

--- a/skipmaskmanager/merged_iterator_test.go
+++ b/skipmaskmanager/merged_iterator_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestMergedIterator(t *testing.T) {
 	iterators := []node.Node{
-		&testIteratorDesc{lids: []uint32{1, 2, 5, 22, 45}},
-		&testIteratorDesc{lids: []uint32{2, 3, 9, 15, 33, 45}},
-		&testIteratorDesc{lids: []uint32{1, 7, 8, 45}},
+		&testIteratorAsc{lids: []uint32{1, 2, 5, 22, 45}},
+		&testIteratorAsc{lids: []uint32{2, 3, 9, 15, 33, 45}},
+		&testIteratorAsc{lids: []uint32{1, 7, 8, 45}},
 	}
 
 	mergedIterator := NewNMergedIterators(iterators)
@@ -30,9 +30,9 @@ func TestMergedIterator(t *testing.T) {
 
 func TestMergedIteratorReverse(t *testing.T) {
 	iterators := []node.Node{
-		&testIteratorAsc{lids: []uint32{45, 22, 5, 2, 1}},
-		&testIteratorAsc{lids: []uint32{45, 33, 15, 9, 3, 2}},
-		&testIteratorAsc{lids: []uint32{45, 8, 7, 1}},
+		&testIteratorDesc{lids: []uint32{45, 22, 5, 2, 1}},
+		&testIteratorDesc{lids: []uint32{45, 33, 15, 9, 3, 2}},
+		&testIteratorDesc{lids: []uint32{45, 8, 7, 1}},
 	}
 
 	mergedIterator := NewNMergedIterators(iterators)
@@ -46,28 +46,6 @@ func TestMergedIteratorReverse(t *testing.T) {
 
 	}
 	require.Equal(t, []uint32{45, 33, 22, 15, 9, 8, 7, 5, 3, 2, 1}, resLIDs)
-}
-
-type testIteratorDesc struct {
-	lids []uint32
-}
-
-func (it *testIteratorDesc) String() string {
-	return "TEST_SKIP_MASK_ITERATOR_DESC"
-}
-
-func (it *testIteratorDesc) Next() node.LID {
-	if len(it.lids) == 0 {
-		return node.NullLID()
-	}
-
-	lid := it.lids[0]
-	it.lids = it.lids[1:]
-	return node.NewDescLID(lid)
-}
-
-func (it *testIteratorDesc) NextGeq(nextID node.LID) node.LID {
-	return node.NullLID()
 }
 
 type testIteratorAsc struct {
@@ -89,5 +67,27 @@ func (it *testIteratorAsc) Next() node.LID {
 }
 
 func (it *testIteratorAsc) NextGeq(nextID node.LID) node.LID {
+	return node.NullLID()
+}
+
+type testIteratorDesc struct {
+	lids []uint32
+}
+
+func (it *testIteratorDesc) String() string {
+	return "TEST_SKIP_MASK_ITERATOR_DESC"
+}
+
+func (it *testIteratorDesc) Next() node.LID {
+	if len(it.lids) == 0 {
+		return node.NullLID()
+	}
+
+	lid := it.lids[0]
+	it.lids = it.lids[1:]
+	return node.NewDescLID(lid)
+}
+
+func (it *testIteratorDesc) NextGeq(nextID node.LID) node.LID {
 	return node.NullLID()
 }

--- a/skipmaskmanager/skip_mask_manager.go
+++ b/skipmaskmanager/skip_mask_manager.go
@@ -224,9 +224,9 @@ func (smm *SkipMaskManager) GetIDsIteratorByFrac(
 		loader := newLoader(f, smm.headersCache)
 		releaseFuncs[i] = loader.release
 		if reverse {
-			iterators = append(iterators, (*IteratorAsc)(NewIterator(loader, minLID, maxLID)))
-		} else {
 			iterators = append(iterators, (*IteratorDesc)(NewIterator(loader, minLID, maxLID)))
+		} else {
+			iterators = append(iterators, (*IteratorAsc)(NewIterator(loader, minLID, maxLID)))
 		}
 	}
 


### PR DESCRIPTION
# Description

Change naming for easier understanding. Now node package uses `asc` which is `true` when lids flow in ascending order. 

For sealed frac iterator names are swapped: `IteratorDesc` <=> `IteratorAsc` (now it's consistent with active fraction)

There are less usages of `reverse` flag as well.

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>