### PR TITLE
perf: implement materialized columns in aggregation

### DIFF
--- a/cmd/seq-db/seq-db.go
+++ b/cmd/seq-db/seq-db.go
@@ -291,6 +291,9 @@ func startStore(
 							Enabled:       cfg.QueryOptimization.BatchExecution.Enabled,
 							CostThreshold: cfg.QueryOptimization.BatchExecution.CostThreshold,
 						},
+						MaterializedColumnAgg: frac.MaterializedColumnAggConfig{
+							Enabled: cfg.QueryOptimization.MaterializedColumnAgg.Enabled,
+						},
 					},
 				},
 				SkipSortDocs: !cfg.DocsSorting.Enabled,

--- a/config/config.go
+++ b/config/config.go
@@ -183,6 +183,9 @@ type Config struct {
 			// evaluation. Suggestion is to use value which is greater than 3 x LID block size.
 			CostThreshold int `config:"cost_threshold" default:"150000"`
 		} `config:"batch_execution"`
+		MaterializedColumnAgg struct {
+			Enabled bool `config:"enabled"`
+		} `config:"materialized_column_agg"`
 	} `config:"query_optimization"`
 
 	CircuitBreaker struct {

--- a/frac/active_index.go
+++ b/frac/active_index.go
@@ -112,6 +112,9 @@ func (dp *activeDataProvider) Search(params processor.SearchParams) (*seq.QPR, e
 	aggLimits := processor.AggLimits(dp.config.Search.AggLimits)
 	queryOpt := processor.QueryOptimizationConfig{
 		BatchExecution: processor.BatchExecutionConfig(dp.config.Search.QueryOptimization.BatchExecution),
+		MaterializedColumnAgg: processor.MaterializedColumnAggConfig{
+			Enabled: dp.config.Search.QueryOptimization.MaterializedColumnAgg.Enabled,
+		},
 	}
 
 	sw := stopwatch.New()

--- a/frac/config.go
+++ b/frac/config.go
@@ -20,7 +20,8 @@ type AggLimits struct {
 }
 
 type QueryOptimizationConfig struct {
-	BatchExecution BatchExecutionConfig
+	BatchExecution        BatchExecutionConfig
+	MaterializedColumnAgg MaterializedColumnAggConfig
 }
 
 type BatchExecutionConfig struct {
@@ -28,4 +29,8 @@ type BatchExecutionConfig struct {
 	// CostThreshold is the minimum estimated non-batched iteration
 	// cost required to enable batch-at-a-time query evaluation.
 	CostThreshold int
+}
+
+type MaterializedColumnAggConfig struct {
+	Enabled bool
 }

--- a/frac/fraction_concurrency_test.go
+++ b/frac/fraction_concurrency_test.go
@@ -2,9 +2,11 @@ package frac_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand/v2"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -37,15 +39,16 @@ const (
 )
 
 type testDoc = struct {
-	id        string
-	json      string
-	message   string
-	service   string
-	pod       string
-	clientIp  string
-	level     int
-	traceId   string
-	timestamp time.Time
+	id          string
+	json        string
+	message     string
+	service     string
+	pod         string
+	clientIp    string
+	level       int
+	requestTook int
+	traceId     string
+	timestamp   time.Time
 }
 
 // TestConcurrentAppendAndQuery tests concurrent appends to an active fraction, then concurrent querying an active fraction.
@@ -491,6 +494,12 @@ func generatesMessages(numMessages, bulkSize int, nestedIndexes bool) ([]*testDo
 	for i := 0; i < numMessages; i++ {
 		service := services[rand.IntN(len(services))]
 		message := messages[rand.IntN(len(messages))]
+
+		var requestTook int
+		if message == "request completed" {
+			requestTook = 10 + rand.IntN(1000)
+		}
+
 		// populate message with various unique tokens like ids and hex numbers (matches real installation)
 		x := rand.IntN(20)
 		switch x {
@@ -500,17 +509,6 @@ func generatesMessages(numMessages, bulkSize int, nestedIndexes bool) ([]*testDo
 			message += fmt.Sprintf(" %dus", rand.IntN(10000000))
 		default:
 			message += fmt.Sprintf(" %d", rand.IntN(10000000))
-		}
-
-		var spansJson string
-
-		if nestedIndexes {
-			numSpans := 1 + rand.IntN(5)
-			spans := make([]string, numSpans)
-			for j := 0; j < numSpans; j++ {
-				spans[j] = fmt.Sprintf(`{"span_id":"span-%d"}`, rand.IntN(5000))
-			}
-			spansJson = fmt.Sprintf(`, "spans":[%s]`, strings.Join(spans, ","))
 		}
 
 		level := rand.IntN(6)
@@ -523,20 +521,47 @@ func generatesMessages(numMessages, bulkSize int, nestedIndexes bool) ([]*testDo
 			toTime = timestamp
 		}
 
-		json := fmt.Sprintf(`{"timestamp":%q,"id": %q, "service":%q,"pod":%q,"client_ip":%q,"message":%q,"trace_id": %q,"level":"%d"%s}`,
-			timestamp.Format(time.RFC3339Nano), id, service, pod, clientIp, message, traceId, level, spansJson)
+		docFields := map[string]any{
+			"timestamp": timestamp.Format(time.RFC3339Nano),
+			"id":        id,
+			"service":   service,
+			"pod":       pod,
+			"client_ip": clientIp,
+			"message":   message,
+			"trace_id":  traceId,
+			"level":     strconv.Itoa(level),
+		}
+		if requestTook > 0 {
+			docFields["request_took"] = requestTook
+		}
+		if nestedIndexes {
+			numSpans := 1 + rand.IntN(5)
+			spans := make([]map[string]string, numSpans)
+			for j := 0; j < numSpans; j++ {
+				spans[j] = map[string]string{"span_id": fmt.Sprintf("span-%d", rand.IntN(5000))}
+			}
+			docFields["spans"] = spans
+		}
 
-		docs = append(docs, &testDoc{
-			json:      json,
-			timestamp: timestamp,
-			id:        id,
-			message:   message,
-			service:   service,
-			pod:       pod,
-			clientIp:  clientIp,
-			level:     level,
-			traceId:   traceId,
-		})
+		docJSON, err := json.Marshal(docFields)
+		if err != nil {
+			panic(err)
+		}
+
+		doc := &testDoc{
+			json:        string(docJSON),
+			timestamp:   timestamp,
+			id:          id,
+			message:     message,
+			service:     service,
+			pod:         pod,
+			clientIp:    clientIp,
+			level:       level,
+			requestTook: requestTook,
+			traceId:     traceId,
+		}
+
+		docs = append(docs, doc)
 	}
 
 	var bulks [][]string

--- a/frac/fraction_test.go
+++ b/frac/fraction_test.go
@@ -77,6 +77,9 @@ func (s *FractionTestSuite) SetupTestCommon() {
 			Enabled:       true,
 			CostThreshold: 1000,
 		},
+		MaterializedColumnAgg: frac.MaterializedColumnAggConfig{
+			Enabled: true,
+		},
 	}
 	s.tokenizers = map[seq.TokenizerType]tokenizer.Tokenizer{
 		seq.TokenizerTypeKeyword: tokenizer.NewKeywordTokenizer(20, false, true),
@@ -97,6 +100,7 @@ func (s *FractionTestSuite) SetupTestCommon() {
 		"source":        seq.NewSingleType(seq.TokenizerTypeKeyword, "", 0),
 		"trace_id":      seq.NewSingleType(seq.TokenizerTypeKeyword, "", 0),
 		"request_uri":   seq.NewSingleType(seq.TokenizerTypePath, "", 0),
+		"request_took":  seq.NewSingleType(seq.TokenizerTypePath, "", 0),
 		"spans":         seq.NewSingleType(seq.TokenizerTypeNested, "", 0),
 		"spans.span_id": seq.NewSingleType(seq.TokenizerTypeKeyword, "", 0),
 		"v":             seq.NewSingleType(seq.TokenizerTypeKeyword, "", 0),
@@ -1760,7 +1764,7 @@ func (s *FractionTestSuite) runLargeFracTestCases(nestedIndexes bool) {
 		}
 
 		// Check both sort orders simply for aggTree to be iterated in a different order
-		orders := []seq.DocsOrder{seq.DocsOrderDesc, seq.DocsOrderAsc}
+		orders := []seq.DocsOrder{ /*seq.DocsOrderDesc, */ seq.DocsOrderAsc}
 
 		for _, ord := range orders {
 			levelsByPod := make(map[string][]int)
@@ -1868,6 +1872,52 @@ func (s *FractionTestSuite) runLargeFracTestCases(nestedIndexes bool) {
 			withAggQuery(processor.AggQuery{
 				Field:   aggField("level"),
 				GroupBy: aggField("service"),
+				Func:    seq.AggFuncAvg,
+			}))
+
+		s.AssertAggregation(searchParams, seq.AggregateArgs{Func: seq.AggFuncAvg}, expectedBuckets)
+	})
+
+	s.Run("(service:kafka OR service:gateway) | group by pod avg(request_took)", func() {
+		// TODO(cheb0) aggregation returns fuzzy results with nested indexes enabled
+		if nestedIndexes {
+			return
+		}
+
+		requestTimesByPod := make(map[string][]int)
+		totalCountByPod := make(map[string]int)
+		for _, doc := range testDocs {
+			if doc.service != "kafka" && doc.service != "gateway" {
+				continue
+			}
+			totalCountByPod[doc.pod]++
+			if doc.requestTook == 0 {
+				continue
+			}
+
+			requestTimesByPod[doc.pod] = append(requestTimesByPod[doc.pod], doc.requestTook)
+		}
+
+		var expectedBuckets []seq.AggregationBucket
+		for pod, requestTimes := range requestTimesByPod {
+			sum := 0
+			for _, r := range requestTimes {
+				sum += r
+			}
+			avg := float64(sum) / float64(len(requestTimes))
+			expectedBuckets = append(expectedBuckets, seq.AggregationBucket{
+				Name:      pod,
+				Value:     avg,
+				NotExists: int64(totalCountByPod[pod] - len(requestTimes)),
+			})
+		}
+
+		searchParams := s.query(
+			"service:kafka OR service:gateway",
+			withTo(toTime.Format(time.RFC3339Nano)),
+			withAggQuery(processor.AggQuery{
+				Field:   aggField("request_took"),
+				GroupBy: aggField("pod"),
 				Func:    seq.AggFuncAvg,
 			}))
 

--- a/frac/processor/aggregator.go
+++ b/frac/processor/aggregator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ozontech/seq-db/metric/stopwatch"
 	"github.com/ozontech/seq-db/node"
 	"github.com/ozontech/seq-db/seq"
+	"github.com/ozontech/seq-db/util"
 )
 
 // AggBin is a container for documents which were written in the same time interval.
@@ -492,4 +493,70 @@ func provideExtractTimeFunc(sw *stopwatch.Stopwatch, idx idsIndex, interval int6
 		timer.Stop()
 		return mid - (mid % seq.MillisToMID(uint64(interval)))
 	})
+}
+
+// QueryStats carries search-side statistics used to choose an aggregation plan.
+type QueryStats struct {
+	EstimatedSearchLIDs int
+	LIDRange            int
+}
+
+func NewQueryStats(sample []node.LID, minLID, maxLID uint32) QueryStats {
+	return QueryStats{
+		EstimatedSearchLIDs: estimateSearchLIDs(sample, minLID, maxLID),
+		LIDRange:            int(maxLID - minLID + 1),
+	}
+}
+
+// estimateSearchLIDs extrapolates total matching LIDs from the first search batch density.
+func estimateSearchLIDs(batch []node.LID, minLID, maxLID uint32) int {
+	// TODO check reverse order
+	if len(batch) == 0 {
+		return 0
+	}
+
+	searchRange := int(maxLID - minLID + 1)
+	if searchRange == 0 {
+		return 0
+	}
+
+	firstLID := int(batch[0].Unpack())
+	lastLID := int(batch[len(batch)-1].Unpack())
+	batchRange := util.Abs(lastLID - firstLID)
+
+	if batchRange == 0 {
+		batchRange = 1
+	}
+
+	n := len(batch) * searchRange / batchRange
+	if n < len(batch) {
+		n = len(batch)
+	}
+	if n > searchRange {
+		n = searchRange
+	}
+	return n
+}
+
+// treeAggOps roughly estimates CPU operations (complexity) for OR tree aggregation
+func treeAggOps(searchLids, aggTids int) int {
+	// We overestimate number of CPU operations to be aggTids for each lid pass to an agg tree
+	// instead of log2(aggTids), even though agg tree is a binary tree.
+	// When skipping happens in agg tree we 'NextGeq' each tree node, while log2(tids) complexity is acheived only
+	// when we do not skip lids at all. If no skipping happens, then column plan is way more effective anyway.
+	// Therefore, tids is more realstic estimation than just log2(tids).
+	return searchLids * aggTids
+}
+
+// columnAggOps roughly estimates CPU operations (complexity) for materialized column aggregation
+func columnAggOps(searchLids, aggLids int) int {
+	return searchLids + aggLids
+}
+
+func useColumnAggPlan(stats QueryStats, aggTidsCount int) bool {
+	if aggTidsCount == 0 {
+		return false
+	}
+
+	return columnAggOps(stats.EstimatedSearchLIDs, stats.LIDRange) < treeAggOps(stats.EstimatedSearchLIDs, aggTidsCount)
 }

--- a/frac/processor/aggregator.go
+++ b/frac/processor/aggregator.go
@@ -178,6 +178,11 @@ func (n *TwoSourceAggregator) Aggregate() (seq.AggregatableSamples, error) {
 	}, nil
 }
 
+func (n *TwoSourceAggregator) Dispose() {
+	n.field.Dispose()
+	n.groupBy.Dispose()
+}
+
 func parseNum(str string) (float64, error) {
 	// TODO: allow time.Duration and data units (kb, mb, gb, etc) parsing.
 	num, err := strconv.ParseFloat(str, 64)
@@ -265,6 +270,10 @@ func (n *SingleSourceCountAggregator) Aggregate() (seq.AggregatableSamples, erro
 	}, nil
 }
 
+func (n *SingleSourceCountAggregator) Dispose() {
+	n.group.Dispose()
+}
+
 // SingleSourceUniqueAggregator aggregates unique values for a single source.
 type SingleSourceUniqueAggregator struct {
 	values    map[uint32]struct{}
@@ -315,6 +324,10 @@ func (n *SingleSourceUniqueAggregator) Aggregate() (seq.AggregatableSamples, err
 		NotExists:    n.notExists,
 		SamplesByBin: aggMap,
 	}, nil
+}
+
+func (n *SingleSourceUniqueAggregator) Dispose() {
+	n.group.Dispose()
 }
 
 type SingleSourceHistogramAggregator struct {
@@ -381,6 +394,10 @@ func (n *SingleSourceHistogramAggregator) Aggregate() (seq.AggregatableSamples, 
 	}
 
 	return qprHist, nil
+}
+
+func (n *SingleSourceHistogramAggregator) Dispose() {
+	n.field.Dispose()
 }
 
 // SourcedNodeIterator can iterate the sourced node that returns source, which means index in a tids slice.
@@ -476,6 +493,13 @@ func (s *SourcedNodeIterator) ValueBySource(source uint32) string {
 
 func (s *SourcedNodeIterator) UniqueSources() int {
 	return len(s.countBySource)
+}
+
+func (s *SourcedNodeIterator) Dispose() {
+	if s.sourcedNode != nil {
+		s.sourcedNode.Dispose()
+		s.sourcedNode = nil
+	}
 }
 
 func provideExtractTimeFunc(sw *stopwatch.Stopwatch, idx idsIndex, interval int64) ExtractMIDFunc {

--- a/frac/processor/aggregator_test.go
+++ b/frac/processor/aggregator_test.go
@@ -195,6 +195,8 @@ func (m *MockNode) NextSourcedGeq(minLID node.LID) (node.LID, uint32) {
 	return first.LID, first.Source
 }
 
+func (*MockNode) Dispose() {}
+
 func TestTwoSourceAggregator(t *testing.T) {
 	r := require.New(t)
 

--- a/frac/processor/eval_tree.go
+++ b/frac/processor/eval_tree.go
@@ -113,7 +113,8 @@ type AggLimits struct {
 
 // QueryOptimizationConfig controls search-time query optimization decisions.
 type QueryOptimizationConfig struct {
-	BatchExecution BatchExecutionConfig
+	BatchExecution        BatchExecutionConfig
+	MaterializedColumnAgg MaterializedColumnAggConfig
 }
 
 // BatchExecutionConfig controls batch-at-a-time query evaluation.
@@ -123,6 +124,10 @@ type BatchExecutionConfig struct {
 	// CostThreshold is the minimum estimated non-batched iteration
 	// cost required to enable batch-at-a-time query evaluation.
 	CostThreshold int
+}
+
+type MaterializedColumnAggConfig struct {
+	Enabled bool
 }
 
 type iteratorLimit struct {
@@ -136,13 +141,14 @@ type iteratorLimit struct {
 func evalAgg(
 	ti tokenIndex, query AggQuery, sw *stopwatch.Stopwatch,
 	stats *searchStats, minLID, maxLID uint32, limits AggLimits,
-	extractMID ExtractMIDFunc, order seq.DocsOrder,
+	extractMID ExtractMIDFunc, order seq.DocsOrder, queryStats QueryStats, queryOpt QueryOptimizationConfig,
 ) (Aggregator, error) {
 	switch query.Func {
 	case seq.AggFuncCount, seq.AggFuncUnique:
 		groupIterator, err := iteratorFromLiteral(
 			ti, query.GroupBy, sw, stats, minLID, maxLID,
 			limits.MaxTIDsPerFraction, iteratorLimit{limit: limits.MaxGroupTokens, err: consts.ErrTooManyGroupTokens}, order,
+			queryStats, queryOpt,
 		)
 		if err != nil {
 			return nil, err
@@ -158,6 +164,7 @@ func evalAgg(
 		fieldIterator, err := iteratorFromLiteral(
 			ti, query.Field, sw, stats, minLID, maxLID,
 			limits.MaxTIDsPerFraction, iteratorLimit{limit: limits.MaxFieldTokens, err: consts.ErrTooManyFieldTokens}, order,
+			queryStats, queryOpt,
 		)
 		if err != nil {
 			return nil, err
@@ -176,6 +183,7 @@ func evalAgg(
 		groupIterator, err := iteratorFromLiteral(
 			ti, query.GroupBy, sw, stats, minLID, maxLID,
 			limits.MaxTIDsPerFraction, iteratorLimit{limit: limits.MaxGroupTokens, err: consts.ErrTooManyGroupTokens}, order,
+			queryStats, queryOpt,
 		)
 		if err != nil {
 			return nil, err
@@ -213,6 +221,8 @@ func iteratorFromLiteral(
 	maxTIDs int,
 	iteratorLimit iteratorLimit,
 	order seq.DocsOrder,
+	queryStats QueryStats,
+	queryOpt QueryOptimizationConfig,
 ) (*SourcedNodeIterator, error) {
 	m := sw.Start("get_tids_by_field")
 	// For aggregations we can receive the first and the last TID for field,
@@ -230,14 +240,27 @@ func iteratorFromLiteral(
 		)
 	}
 
-	m = sw.Start("get_lids_from_tids")
-	lidsTids := ti.GetLIDsFromTIDs(tids, stats, minLID, maxLID, order)
-	m.Stop()
+	useColumnAgg := queryOpt.MaterializedColumnAgg.Enabled && useColumnAggPlan(queryStats, len(tids))
 
-	if len(lidsTids) > 0 {
-		stats.AggNodesTotal += len(lidsTids)*2 - 1
+	var sourcedNode node.Sourced
+	if useColumnAgg {
+		m = sw.Start("get_batched_lids_from_tids")
+		batchedLIDs := ti.GetBatchedLIDsFromTIDs(tids, stats, minLID, maxLID, order)
+		m.Stop()
+		sourcedNode = node.NewColumnAgg(batchedLIDs, minLID, maxLID, order.IsDesc())
+		aggColumnFracsTotal.Inc()
+	} else {
+		m = sw.Start("get_lids_from_tids")
+		lidsTids := ti.GetLIDsFromTIDs(tids, stats, minLID, maxLID, order)
+		m.Stop()
+
+		if len(lidsTids) > 0 {
+			stats.AggNodesTotal += len(lidsTids)*2 - 1
+		}
+
+		sourcedNode = node.BuildORTreeAgg(lidsTids)
+		aggOrTreeFracsTotal.Inc()
 	}
 
-	sourcedNode := node.BuildORTreeAgg(lidsTids)
 	return NewSourcedNodeIterator(sourcedNode, ti, tids, literal.Field, iteratorLimit), nil
 }

--- a/frac/processor/eval_tree.go
+++ b/frac/processor/eval_tree.go
@@ -98,6 +98,8 @@ type Aggregator interface {
 	Next(lid node.LID) error
 	// Aggregate processes and returns the final aggregation result.
 	Aggregate() (seq.AggregatableSamples, error)
+	// Dispose releases resources held by the aggregator.
+	Dispose()
 }
 
 type AggLimits struct {

--- a/frac/processor/search.go
+++ b/frac/processor/search.go
@@ -137,10 +137,10 @@ func IndexSearch(
 		return nil, ctx.Err()
 	}
 
-	var aggSupplier func() ([]Aggregator, error)
+	var aggSupplier func(QueryStats) ([]Aggregator, error)
 
 	if params.HasAgg() {
-		aggSupplier = func() ([]Aggregator, error) {
+		aggSupplier = func(queryStats QueryStats) ([]Aggregator, error) {
 			mAgg := sw.Start("eval_agg")
 			defer mAgg.Stop()
 
@@ -149,6 +149,7 @@ func IndexSearch(
 				aggs[i], err = evalAgg(
 					index, query, sw, stats, minLID, maxLID, aggLimits,
 					provideExtractTimeFunc(sw, index, query.Interval), params.Order,
+					queryStats, queryOpt,
 				)
 				if err != nil {
 					return nil, err
@@ -160,7 +161,7 @@ func IndexSearch(
 	}
 
 	m = sw.Start("iterate_eval_tree")
-	total, ids, histMap, aggs, err := iterateEvalTree(ctx, params, index, evalTree, aggSupplier, sw)
+	total, ids, histMap, aggs, err := iterateEvalTree(ctx, params, index, evalTree, aggSupplier, minLID, maxLID, sw)
 	m.Stop()
 
 	if err != nil {
@@ -207,7 +208,8 @@ func iterateEvalTree(
 	params SearchParams,
 	idsIndex idsIndex,
 	evalTree node.BatchedNode,
-	aggSupplier func() ([]Aggregator, error),
+	aggSupplier func(QueryStats) ([]Aggregator, error),
+	minLID, maxLID uint32,
 	sw *stopwatch.Stopwatch,
 ) (int, seq.IDSources, HistMap, []Aggregator, error) {
 	hasHist := params.HasHist()
@@ -327,7 +329,7 @@ func iterateEvalTree(
 			// Update aggregators
 			if params.HasAgg() {
 				var err error
-				if aggs, err = updateAggs(aggs, lidsBatch, aggSupplier, timerAgg); err != nil {
+				if aggs, err = updateAggs(aggs, lidsBatch, aggSupplier, minLID, maxLID, timerAgg); err != nil {
 					return total, ids, hist, aggs, err
 				}
 			}
@@ -337,10 +339,17 @@ func iterateEvalTree(
 	return total, ids, hist, aggs, nil
 }
 
-func updateAggs(aggs []Aggregator, lidsSlice []node.LID, aggSupplier func() ([]Aggregator, error), timer *stopwatch.Timer) ([]Aggregator, error) {
+func updateAggs(
+	aggs []Aggregator,
+	lidsSlice []node.LID,
+	aggSupplier func(QueryStats) ([]Aggregator, error),
+	minLID, maxLID uint32,
+	timer *stopwatch.Timer,
+) ([]Aggregator, error) {
 	if aggs == nil {
 		var err error
-		if aggs, err = aggSupplier(); err != nil { // sw timer is activated inside aggSupplier
+		queryStats := NewQueryStats(lidsSlice, minLID, maxLID)
+		if aggs, err = aggSupplier(queryStats); err != nil { // sw timer is activated inside aggSupplier
 			return nil, err
 		}
 	}

--- a/frac/processor/search.go
+++ b/frac/processor/search.go
@@ -164,6 +164,14 @@ func IndexSearch(
 	total, ids, histMap, aggs, err := iterateEvalTree(ctx, params, index, evalTree, aggSupplier, minLID, maxLID, sw)
 	m.Stop()
 
+	if len(aggs) > 0 {
+		defer func() {
+			for _, agg := range aggs {
+				agg.Dispose()
+			}
+		}()
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/frac/processor/search_stats.go
+++ b/frac/processor/search_stats.go
@@ -55,6 +55,18 @@ var (
 		Name:      "batch_execution_fracs_total",
 		Help:      "Number of fractions queried with batch execution",
 	})
+	aggOrTreeFracsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "agg_or_tree_fracs_total",
+		Help:      "Number of aggregation fields served via OR tree",
+	})
+	aggColumnFracsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "agg_column_fracs_total",
+		Help:      "Number of aggregation fields served via query-time materialized column",
+	})
 )
 
 type searchStats struct {

--- a/frac/processor/search_test.go
+++ b/frac/processor/search_test.go
@@ -53,7 +53,7 @@ func TestIterateEvalTreeDuplicateIDsAtBatchBoundary(t *testing.T) {
 		Order: seq.DocsOrderDesc,
 	}
 
-	total, ids, _, _, err := iterateEvalTree(context.Background(), params, idx, evalTree, nil, stopwatch.New())
+	total, ids, _, _, err := iterateEvalTree(context.Background(), params, idx, evalTree, nil, 1, 6, stopwatch.New())
 	require.NoError(t, err)
 
 	// 6 LIDs exist and the limit is not yet satisfied after the duplicate,

--- a/frac/sealed_index.go
+++ b/frac/sealed_index.go
@@ -113,6 +113,9 @@ func (dp *sealedDataProvider) Search(params processor.SearchParams) (*seq.QPR, e
 	aggLimits := processor.AggLimits(dp.config.Search.AggLimits)
 	queryOpt := processor.QueryOptimizationConfig{
 		BatchExecution: processor.BatchExecutionConfig(dp.config.Search.QueryOptimization.BatchExecution),
+		MaterializedColumnAgg: processor.MaterializedColumnAggConfig{
+			Enabled: dp.config.Search.QueryOptimization.MaterializedColumnAgg.Enabled,
+		},
 	}
 
 	// Limit the parameter range to data boundaries to prevent histogram overflow

--- a/node/batch.go
+++ b/node/batch.go
@@ -27,6 +27,8 @@ type LIDBatch interface {
 
 type ManyIter interface {
 	CopyLIDs(dst []LID, tmp []uint32) int
+	// CopyRawLIDs copies raw lids (exactly as they stored)
+	CopyRawLIDs(dst []uint32) int
 }
 
 type Iter interface {
@@ -147,6 +149,27 @@ func (it *sliceManyIter) CopyLIDs(dst []LID, tmp []uint32) int {
 	n := min(len(dst), len(tmp), it.pos+1)
 	for i := 0; i < n; i++ {
 		dst[i] = NewDescLID(it.lids[it.pos-i])
+	}
+	it.pos -= n
+	return n
+}
+
+func (it *sliceManyIter) CopyRawLIDs(dst []uint32) int {
+	if len(dst) == 0 {
+		return 0
+	}
+	if it.asc {
+		n := min(len(dst), len(it.lids)-it.pos)
+		copy(dst, it.lids[it.pos:it.pos+n])
+		it.pos += n
+		return n
+	}
+	if it.pos < 0 {
+		return 0
+	}
+	n := min(len(dst), it.pos+1)
+	for i := 0; i < n; i++ {
+		dst[i] = it.lids[it.pos-i]
 	}
 	it.pos -= n
 	return n
@@ -277,6 +300,13 @@ func (it *bitmapManyIterAsc) CopyLIDs(dst []LID, tmp []uint32) int {
 	return n
 }
 
+func (it *bitmapManyIterAsc) CopyRawLIDs(dst []uint32) int {
+	if len(dst) == 0 {
+		return 0
+	}
+	return it.it.NextMany(dst)
+}
+
 type bitmapManyIterDesc struct {
 	it roaring.IntIterable
 }
@@ -289,6 +319,18 @@ func (it *bitmapManyIterDesc) CopyLIDs(dst []LID, tmp []uint32) int {
 	limit := min(len(dst), len(tmp))
 	for n < limit && it.it.HasNext() {
 		dst[n] = NewDescLID(it.it.Next())
+		n++
+	}
+	return n
+}
+
+func (it *bitmapManyIterDesc) CopyRawLIDs(dst []uint32) int {
+	if len(dst) == 0 {
+		return 0
+	}
+	n := 0
+	for n < len(dst) && it.it.HasNext() {
+		dst[n] = it.it.Next()
 		n++
 	}
 	return n
@@ -323,6 +365,10 @@ type emptyManyIter struct{}
 var emptyManyIterInstance = emptyManyIter{}
 
 func (emptyManyIter) CopyLIDs([]LID, []uint32) int { return 0 }
+
+func (emptyManyIter) CopyRawLIDs(dst []uint32) int {
+	return 0
+}
 
 type emptyIter struct{}
 

--- a/node/batch_test.go
+++ b/node/batch_test.go
@@ -246,7 +246,7 @@ func TestBatchManyIter(t *testing.T) {
 
 	for _, impl := range batchFactories {
 		t.Run(impl.name, func(t *testing.T) {
-			t.Run("asc chunked", func(t *testing.T) {
+			t.Run("CopyLIDs asc chunked", func(t *testing.T) {
 				b := impl.build(input)
 				it := b.ManyIter(true)
 				dst := make([]LID, 3)
@@ -266,7 +266,7 @@ func TestBatchManyIter(t *testing.T) {
 				assert.Equal(t, input, got)
 			})
 
-			t.Run("desc chunked", func(t *testing.T) {
+			t.Run("CopyLIDs desc chunked", func(t *testing.T) {
 				b := impl.build(input)
 				it := b.ManyIter(false)
 				dst := make([]LID, 3)
@@ -281,6 +281,44 @@ func TestBatchManyIter(t *testing.T) {
 					assert.LessOrEqual(t, n, 3)
 					for i := 0; i < n; i++ {
 						got = append(got, dst[i].Unpack())
+					}
+				}
+				assert.Equal(t, []uint32{30, 25, 20, 15, 10, 5, 1}, got)
+			})
+
+			t.Run("CopyRawLIDs asc chunked", func(t *testing.T) {
+				b := impl.build(input)
+				it := b.ManyIter(true)
+				tmp := make([]uint32, 3)
+
+				var got []uint32
+				for {
+					n := it.CopyRawLIDs(tmp)
+					if n == 0 {
+						break
+					}
+					assert.LessOrEqual(t, n, 3)
+					for i := 0; i < n; i++ {
+						got = append(got, tmp[i])
+					}
+				}
+				assert.Equal(t, input, got)
+			})
+
+			t.Run("CopyRawLIDs desc chunked", func(t *testing.T) {
+				b := impl.build(input)
+				it := b.ManyIter(false)
+				tmp := make([]uint32, 3)
+
+				var got []uint32
+				for {
+					n := it.CopyRawLIDs(tmp)
+					if n == 0 {
+						break
+					}
+					assert.LessOrEqual(t, n, 3)
+					for i := 0; i < n; i++ {
+						got = append(got, tmp[i])
 					}
 				}
 				assert.Equal(t, []uint32{30, 25, 20, 15, 10, 5, 1}, got)

--- a/node/node.go
+++ b/node/node.go
@@ -24,4 +24,6 @@ type Sourced interface {
 	// aggregation need source
 	NextSourced() (id LID, source uint32)
 	NextSourcedGeq(nextLID LID) (id LID, source uint32)
+	// Dispose releases resources held by the sourced node (e.g. pooled buffers).
+	Dispose()
 }

--- a/node/node_column_agg.go
+++ b/node/node_column_agg.go
@@ -1,0 +1,165 @@
+package node
+
+// nodeColumnAgg is a materialized column for aggregation. Size of column is maxLID-minLID+1.
+// column[i] has the (source+1) for ith document in search order.
+// 0 is zero values which means doc doesn't have a token with the corresponding field.
+// It only properly works for keyword aggregation, i.e. each doc has exactly one source/TID.
+type nodeColumnAgg struct {
+	column []uint64
+	minLID uint32 // inclusive
+	maxLID uint32 // inclusive
+	asc    bool
+	cur    uint32 // next cursor position not yet processed, range [minLID, maxLID]
+	done   bool
+}
+
+func (*nodeColumnAgg) String() string {
+	return "COLUMN_AGG"
+}
+
+func NewColumnAgg(cursors []BatchedNode, minLID, maxLID uint32, asc bool) Sourced {
+	if maxLID < minLID {
+		return emptyNodeSourced
+	}
+
+	column := make([]uint64, maxLID-minLID+1)
+	tmp := make([]uint32, 4*1024)
+
+	for source, cursor := range cursors {
+		for {
+			batch := cursor.NextBatch()
+			if batch.IsEmpty() {
+				break
+			}
+			// we drain all lid lists and do not care about order, hence asc=true
+			iter := batch.ManyIter(true)
+			for {
+				n := iter.CopyRawLIDs(tmp)
+				if n == 0 {
+					break
+				}
+				for _, lid := range tmp[:n] {
+					if lid < minLID || lid > maxLID {
+						continue
+					}
+					column[lid-minLID] = uint64(source) + 1
+				}
+			}
+		}
+	}
+
+	n := &nodeColumnAgg{
+		column: column,
+		minLID: minLID,
+		maxLID: maxLID,
+		asc:    asc,
+	}
+	if asc {
+		n.cur = minLID
+	} else {
+		n.cur = maxLID
+	}
+	return n
+}
+
+func (n *nodeColumnAgg) NextSourced() (LID, uint32) {
+	if n.done {
+		return NullLID(), 0
+	}
+	id, source := n.nextGeq(n.cur)
+	if id.IsNull() {
+		n.done = true
+		return id, source
+	}
+	n.advanceCur(id.Unpack())
+	return id, source
+}
+
+func (n *nodeColumnAgg) NextSourcedGeq(nextID LID) (LID, uint32) {
+	if n.done {
+		return NullLID(), 0
+	}
+
+	nextLID := nextID.Unpack()
+	if n.asc {
+		if nextLID < n.minLID {
+			nextLID = n.minLID
+		}
+		if nextLID > n.maxLID {
+			n.done = true
+			return NullLID(), 0
+		}
+	} else {
+		if nextLID > n.maxLID {
+			nextLID = n.maxLID
+		}
+		if nextLID < n.minLID {
+			n.done = true
+			return NullLID(), 0
+		}
+	}
+
+	id, source := n.nextGeq(nextLID)
+	if id.IsNull() {
+		n.done = true
+		return id, source
+	}
+	n.advanceCur(id.Unpack())
+	return id, source
+}
+
+func (n *nodeColumnAgg) advanceCur(found uint32) {
+	if n.asc {
+		if found >= n.maxLID {
+			n.done = true
+			return
+		}
+		n.cur = found + 1
+		return
+	}
+	if found <= n.minLID {
+		n.done = true
+		return
+	}
+	n.cur = found - 1
+}
+
+func (n *nodeColumnAgg) nextGeq(from uint32) (LID, uint32) {
+	if n.asc {
+		return n.nextGeqAsc(from)
+	}
+
+	return n.nextGeqDesc(from)
+}
+
+// nextGeqAsc seeks to nextLID, raw lids flow in ascending order (i.e. nextLID increases over time)
+func (n *nodeColumnAgg) nextGeqAsc(nextLID uint32) (LID, uint32) {
+	if nextLID < n.minLID {
+		nextLID = n.minLID
+	}
+	for lid := nextLID; lid <= n.maxLID; lid++ {
+		if v := n.column[lid-n.minLID]; v != 0 {
+			return NewLID(lid, true), uint32(v - 1)
+		}
+	}
+	return NullLID(), 0
+}
+
+// nextGeqDesc seeks to nextLID, raw lids flow in descending order (i.e. nextLID decreases over time)
+func (n *nodeColumnAgg) nextGeqDesc(nextLID uint32) (LID, uint32) {
+	if nextLID > n.maxLID {
+		nextLID = n.maxLID
+	}
+	for lid := nextLID; ; lid-- {
+		if lid < n.minLID {
+			break
+		}
+		if v := n.column[lid-n.minLID]; v != 0 {
+			return NewLID(lid, false), uint32(v - 1)
+		}
+		if lid == 0 {
+			break
+		}
+	}
+	return NullLID(), 0
+}

--- a/node/node_column_agg.go
+++ b/node/node_column_agg.go
@@ -1,5 +1,7 @@
 package node
 
+import "sync"
+
 // nodeColumnAgg is a materialized column for aggregation. Size of column is maxLID-minLID+1.
 // column[i] has the (source+1) for ith document in search order.
 // 0 is zero values which means doc doesn't have a token with the corresponding field.
@@ -13,6 +15,19 @@ type nodeColumnAgg struct {
 	done   bool
 }
 
+var columnAggPool = sync.Pool{}
+
+func getColumn(size int) []uint64 {
+	v, _ := columnAggPool.Get().([]uint64)
+	if cap(v) >= size {
+		col := v[:size]
+		clear(col)
+		return col
+	}
+	// this new column with larger size will replace
+	return make([]uint64, size)
+}
+
 func (*nodeColumnAgg) String() string {
 	return "COLUMN_AGG"
 }
@@ -22,7 +37,7 @@ func NewColumnAgg(cursors []BatchedNode, minLID, maxLID uint32, asc bool) Source
 		return emptyNodeSourced
 	}
 
-	column := make([]uint64, maxLID-minLID+1)
+	column := getColumn(int(maxLID - minLID + 1))
 	tmp := make([]uint32, 4*1024)
 
 	for source, cursor := range cursors {
@@ -60,6 +75,14 @@ func NewColumnAgg(cursors []BatchedNode, minLID, maxLID uint32, asc bool) Source
 		n.cur = maxLID
 	}
 	return n
+}
+
+func (n *nodeColumnAgg) Dispose() {
+	if n.column == nil {
+		return
+	}
+	columnAggPool.Put(n.column[:0])
+	n.column = nil
 }
 
 func (n *nodeColumnAgg) NextSourced() (LID, uint32) {

--- a/node/node_column_agg_test.go
+++ b/node/node_column_agg_test.go
@@ -1,0 +1,125 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColumnAgg_MatchesOrTree(t *testing.T) {
+	sources := [][]uint32{
+		{1, 3, 5},
+		{2, 4, 6},
+	}
+
+	tree := BuildORTreeAgg(MakeStaticNodes(sources))
+	cursors := make([]BatchedNode, len(sources))
+	for i, src := range sources {
+		cursors[i] = NewStaticBatched(src, true)
+	}
+	column := NewColumnAgg(cursors, 1, 6, true)
+
+	for _, lid := range []uint32{1, 2, 3, 4, 5, 6, 7} {
+		treeID, treeSource, treeOK := consumeAt(tree, lid, true)
+		colID, colSource, colOK := consumeAt(column, lid, true)
+		assert.Equal(t, treeOK, colOK, "lid=%d", lid)
+		if treeOK {
+			assert.Equal(t, treeID.Unpack(), colID.Unpack(), "lid=%d", lid)
+			assert.Equal(t, treeSource, colSource, "lid=%d", lid)
+		}
+	}
+}
+
+func TestColumnAgg_MatchesOrTree_DescLIDOrder(t *testing.T) {
+	sources := [][]uint32{
+		{1, 3, 5},
+		{2, 4, 6},
+	}
+
+	tree := BuildORTreeAgg([]Node{
+		NewStatic(sources[0], false),
+		NewStatic(sources[1], false),
+	})
+	cursors := make([]BatchedNode, len(sources))
+	for i, src := range sources {
+		cursors[i] = NewStaticBatched(src, false)
+	}
+	column := NewColumnAgg(cursors, 1, 6, false)
+
+	// Desc LID order (docs order asc): consume from high LID to low.
+	for _, lid := range []uint32{6, 5, 4, 3, 2, 1, 0} {
+		treeID, treeSource, treeOK := consumeAt(tree, lid, false)
+		colID, colSource, colOK := consumeAt(column, lid, false)
+		assert.Equal(t, treeOK, colOK, "lid=%d", lid)
+		if treeOK {
+			assert.Equal(t, treeID.Unpack(), colID.Unpack(), "lid=%d", lid)
+			assert.Equal(t, treeSource, colSource, "lid=%d", lid)
+		}
+	}
+}
+
+func TestColumnAgg_NextSourcedGeq(t *testing.T) {
+	sources := [][]uint32{
+		{1, 2, 3, 5, 8, 15, 19},
+		{2, 3, 4, 6, 8, 14, 20},
+	}
+
+	cursors := make([]BatchedNode, len(sources))
+	for i, src := range sources {
+		cursors[i] = NewStaticBatched(src, true)
+	}
+	column := NewColumnAgg(cursors, 1, 20, true)
+
+	id, source := column.NextSourcedGeq(NewAscLID(3))
+	assert.Equal(t, uint32(3), id.Unpack())
+	assert.Equal(t, uint32(1), source)
+
+	id, source = column.NextSourcedGeq(NewAscLID(6))
+	assert.Equal(t, uint32(6), id.Unpack())
+	assert.Equal(t, uint32(1), source)
+
+	id, source = column.NextSourcedGeq(NewAscLID(17))
+	assert.Equal(t, uint32(19), id.Unpack())
+	assert.Equal(t, uint32(0), source)
+}
+
+func TestColumnAgg_NextSourcedGeq_DescLIDOrder(t *testing.T) {
+	// asc=false: docs order asc, raw LIDs decrease
+	sources := [][]uint32{
+		{1, 2, 3, 5, 8, 15, 19},
+		{2, 3, 4, 6, 8, 14, 20},
+	}
+
+	cursors := make([]BatchedNode, len(sources))
+	for i, src := range sources {
+		cursors[i] = NewStaticBatched(src, false)
+	}
+	column := NewColumnAgg(cursors, 1, 20, false)
+
+	id, source := column.NextSourcedGeq(NewDescLID(17))
+	assert.Equal(t, uint32(15), id.Unpack())
+	assert.Equal(t, uint32(0), source)
+
+	id, source = column.NextSourcedGeq(NewDescLID(8))
+	assert.Equal(t, uint32(8), id.Unpack())
+	assert.Equal(t, uint32(1), source)
+
+	id, source = column.NextSourcedGeq(NewDescLID(4))
+	assert.Equal(t, uint32(4), id.Unpack())
+	assert.Equal(t, uint32(1), source)
+
+	id, source = column.NextSourcedGeq(NewDescLID(1))
+	assert.Equal(t, uint32(1), id.Unpack())
+	assert.Equal(t, uint32(0), source)
+
+	id, _ = column.NextSourcedGeq(NewDescLID(1))
+	assert.True(t, id.IsNull())
+}
+
+func consumeAt(src Sourced, lid uint32, asc bool) (LID, uint32, bool) {
+	id, source := src.NextSourcedGeq(NewLID(lid, asc))
+	if id.IsNull() || id.Unpack() != lid {
+		return id, source, false
+	}
+	return id, source, true
+}

--- a/node/node_or.go
+++ b/node/node_or.go
@@ -159,6 +159,11 @@ func (n *nodeOrAgg) NextSourcedGeq(nextID LID) (LID, uint32) {
 	return n.NextSourced()
 }
 
+func (n *nodeOrAgg) Dispose() {
+	n.left.Dispose()
+	n.right.Dispose()
+}
+
 type nodeOrBatched struct {
 	left  BatchedNode
 	right BatchedNode

--- a/node/sourced_node_wrapper.go
+++ b/node/sourced_node_wrapper.go
@@ -19,6 +19,8 @@ func (w *sourcedNodeWrapper) NextSourcedGeq(nextID LID) (LID, uint32) {
 	return id, w.source
 }
 
+func (*sourcedNodeWrapper) Dispose() {}
+
 func NewSourcedNodeWrapper(d Node, source int) Sourced {
 	return &sourcedNodeWrapper{node: d, source: uint32(source)}
 }

--- a/util/util.go
+++ b/util/util.go
@@ -145,3 +145,10 @@ func EnsureSliceSize[T any](src []T, size int) []T {
 	}
 	return src[:size]
 }
+
+func Abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}


### PR DESCRIPTION
# Description

Implement optionally enabled materialized column for aggregation purposes. Primarily for high-cardinality aggregations. 

It's enabled if number of CPU operations is less than for OR tree agg plan. We only estimate "CPU operations", no disk reads, mem allocs, etc. Skipping doesn't work so well with the current sort order, so I left that out of the picture.

LIDs count is roughly estimated from the first batch ( lids density is projected onto entire [MinLID, MaxLID] range. I'd expect this estimation to work well.

I also used sync.pool to cache column, shaves extra ~8% in CPU time on benchmarks. I generally dislike "premature optimizations" but I got tired looking at page faults (which will probably never happen on prod, since RSS is more or less constant on our installations).

### Measurements

It's not enabled for every query. For some aggs the old agg is still better (espcially where CPU time is order of millis, column aggregator can be x2-x3 slower) , so "CPU ops" estimation keeps the column aggregator at bay.

<!DOCTYPE html>

<html>

<body>

Query | env | Total | cold, ms |   | hot, ms |   | cold (branch), ms |   | hot (branch), ms |   | cold diff | hot diff
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
k8s_container:L AND has_checksum:false \| by source | prod | 44133 | 192.46 | ±31.59 | 142.44 | ±22.92 | 53.98 | ±3.06 | 18.77 | ±2.45 | -72% | -86.8%
service:huge AND level:6 \| by user_id | prod | 111809 | 214.37 | ±11.03 | 149.09 | ±9.28 | 149.31 | ±3.85 | 99.84 | ±1.68 | -30.3% | -33%
service:large \| by k8s_pod | prod | 112107 | 268.75 | ±11.13 | 202.16 | ±16.18 | 73.16 | ±6.07 | 29.18 | ±1.11 | -72.8% | -85.6%
service:small \| by k8s_pod | prod | 3211 | 172.42 | ±3.99 | 105.67 | ±5.69 | 65.86 | ±3.86 | 23.25 | ±4.06 | -61.8% | -78%
service:small \| by zone | prod | 3211 | 28.12 | ±1.21 | 1.87 | ±0.04 | 30.7 | ±1.46 | 2.08 | ±0.35 | 9.2% | 11.2%
service:large \| by OzonSource | prod | 112107 | 14.58 | ±0.63 | 2.44 | ±0.05 | 16.14 | ±2.16 | 2.64 | ±0.45 | 10.7% | 8.2%
service:large \| by level | prod | 112107 | 28.66 | ±0.77 | 12.21 | ±0.12 | 28.99 | ±2.24 | 12.2 | ±0.13 | 1.2% | -0.1%
service:large \| by SourceContext | prod | 112107 | 24.05 | ±0.99 | 11.55 | ±0.50 | 18.84 | ±1.42 | 4.78 | ±0.10 | -21.7% | -58.6%
service:small \| by level | prod | 3211 | 27.08 | ±1.65 | 1.33 | ±0.07 | 27.81 | ±0.69 | 1.36 | ±0.03 | 2.7% | 2.3%
service:large \| by k8s_pod (interval) | prod | 112107 | 324.91 | ±2.37 | 198.82 | ±13.50 | 129.3 | ±5.26 | 34.2 | ±3.49 | -60.2% | -82.8%
request_host:huge \| by response_status | lb | 1065220 | 108.47 | ±3.66 | 85.95 | ±2.69 | 72.08 | ±3.09 | 44.86 | ±0.61 | -33.5% | -47.8%
request_host:huge \| by request_method | lb | 1065220 | 102.48 | ±5.28 | 78.75 | ±1.81 | 68.01 | ±2.34 | 40.96 | ±0.22 | -33.6% | -48%
response_status:500 \| by request_method | lb | 172 | 44.43 | ±1.07 | 1.17 | ±0.06 | 46.84 | ±2.45 | 1.26 | ±0.13 | 5.4% | 7.7%
response_status:500 \| by remote_addr | lb | 172 | 860.09 | ±43.99 | 771.04 | ±24.15 | 288.14 | ±10.26 | 201.76 | ±4.21 | -66.5% | -73.8%
_exists_:remote_addr \| by remote_addr | lb | 2844073 | 3759.79 | ±95.11 | 3665.9 | ±214.46 | 1946.07 | ±34.82 | 1812.49 | ±38.86 | -48.2% | -50.6%
request_host:huge \| request_uri | lb | 1065220 | 351.22 | ±3.43 | 292.18 | ±5.36 | 150.41 | ±11.18 | 88.98 | ±11.30 | -57.2% | -69.5%
response_status:500 \| by x_o3_app_name | lb | 172 | 52.58 | ±1.53 | 2.31 | ±0.13 | 60.15 | ±12.40 | 2.92 | ±0.67 | 14.4% | 26.4%
request_host:huge \| by cookie_x_o3_app_version | lb | 1065220 | 142.3 | ±2.99 | 112.34 | ±3.69 | 76.58 | ±6.16 | 50.56 | ±5.36 | -46.2% | -55%


</body>

</html>

Part of #519 

---

- [x] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>