### PR TITLE
fix(stream search): support legacy count agg format

### DIFF
--- a/proxyapi/grpc_complex_search.go
+++ b/proxyapi/grpc_complex_search.go
@@ -232,6 +232,13 @@ func buildStreamSearchReqFromComplexSearchReq(
 	// stream search serves either documents or a single agg.
 	// shouldUseStreamSearch guarantees single agg and no histogram.
 	if len(req.Aggs) == 1 {
+		// Support legacy format in which field means groupBy.
+		agg := req.Aggs[0]
+		if agg.Func == seqproxyapi.AggFunc_AGG_FUNC_COUNT && agg.Field != "" {
+			agg.GroupBy = agg.Field
+			agg.Field = ""
+		}
+
 		aggQuery, err := convertAggsQuery(req.Aggs)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description

support legacy count agg format in which field means groupBy.

---

- [ ] I have read and followed all requirements in [CONTRIBUTING.md](https://github.com/ozontech/seq-db/blob/main/.github/CONTRIBUTING.md);
- [ ] I used LLM/AI assistance to make this pull request;

If you have used LLM/AI assistance please provide model name and full prompt:

```
Model: {{model-name}}
Prompt: {{prompt}}
```
